### PR TITLE
Small changes made while exploring

### DIFF
--- a/appinsights/src/config.rs
+++ b/appinsights/src/config.rs
@@ -28,7 +28,7 @@ pub struct TelemetryConfig {
     /// Endpoint URL where data will be sent.
     endpoint: String,
 
-    // Maximum time to wait until send a batch of telemetry.
+    /// Maximum time to wait until send a batch of telemetry.
     interval: Duration,
 }
 

--- a/appinsights/src/config.rs
+++ b/appinsights/src/config.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 /// let config = TelemetryConfig::new("<instrumentation key>".to_string());
 /// ```
 ///
-/// Creating a telemetry client configuration with customg settings
+/// Creating a telemetry client configuration with custom settings
 /// ```rust
 /// # use std::time::Duration;
 /// # use appinsights::TelemetryConfig;

--- a/appinsights/src/time.rs
+++ b/appinsights/src/time.rs
@@ -8,7 +8,7 @@ use std::time::Duration as StdDuration;
 mod imp {
     use chrono::{DateTime, Utc};
 
-    /// Returns a DataTime which corresponds a current date.
+    /// Returns a DateTime which corresponds to a current date.
     pub fn now() -> DateTime<Utc> {
         Utc::now()
     }

--- a/appinsights/src/time.rs
+++ b/appinsights/src/time.rs
@@ -22,7 +22,7 @@ mod imp {
 
     thread_local!(static NOW: RefCell<Option<DateTime<Utc>>> = RefCell::new(None));
 
-    /// Returns a DataTime which corresponds a current date or the value user set in advance.
+    /// Returns a DateTime which corresponds to a current date or the value user set in advance.
     pub fn now() -> DateTime<Utc> {
         NOW.with(|ts| if let Some(now) = *ts.borrow() { now } else { Utc::now() })
     }


### PR DESCRIPTION
Hi Denis, just poking through the code on the bus this morning and noticed a few spelling errors as I ran tests and explored. 

One thing I hadn't seen that I would love some clarity on is the syntax

```rust
#[cfg(not(test))]
```