### PR TITLE
Fix worker channels concurrency issues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 - [x] Setup default context
 - [x] Add examples how to configure context (and pass to context)
 - [x] Fix mutability inconvenience for tags
-- [ ] Throttle sending when items read from events_channel using limits from client config
+- [x] Throttle sending when items read from events_channel using limits from client config
 - [ ] Add keywords to Cargo.toml
 - [ ] Make flush and close operations work in a predictable manner
 - [ ] Make flush_channel_and_wait() ?

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,7 @@
 - [x] Setup default context
 - [x] Add examples how to configure context (and pass to context)
 - [x] Fix mutability inconvenience for tags
+- [ ] Throttle sending when items read from events_channel using limits from client config
 - [ ] Add keywords to Cargo.toml
 - [ ] Make flush and close operations work in a predictable manner
 - [ ] Make flush_channel_and_wait() ?

--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,10 @@
 - [x] Setup default context
 - [x] Add examples how to configure context (and pass to context)
 - [x] Fix mutability inconvenience for tags
-- [x] Throttle sending when items read from events_channel using limits from client config
 - [x] Add keywords to Cargo.toml
-- [ ] Make flush and close operations work in a predictable manner
+- [x] Make flush and close operations work in a predictable manner
+- [ ] Check that telemetry items are not lost when server unavailable (500) and all retries exhausted
+- [ ] Throttle sending when items read from events_channel using limits from client config
 - [ ] Make flush_channel_and_wait() ?
 - [ ] Revisit telemetry client, items and context user facing methods 
 - [ ] make Stats immutable

--- a/appinsights/src/channel/state.rs
+++ b/appinsights/src/channel/state.rs
@@ -153,15 +153,15 @@ impl Worker {
     }
 
     fn handle_sending<E: Event>(&self, m: Machine<Sending, E>, items: &mut Vec<Envelope>) -> Variant {
+        // read items from a channel
+        let pending_items = self.event_receiver.try_iter();
+        items.extend(pending_items);
+
         debug!(
             "Sending {} telemetry items triggered by {:?}",
             items.len(),
             m.trigger().unwrap()
         );
-
-        // read items from a channel
-        let pending_items = self.event_receiver.try_iter();
-        items.extend(pending_items);
 
         // submit items to the server if any
         if items.is_empty() {

--- a/appinsights/src/channel/state.rs
+++ b/appinsights/src/channel/state.rs
@@ -106,19 +106,6 @@ impl Worker {
 
         loop {
             select! {
-                recv(self.event_receiver) -> event => {
-                    match event {
-                        Ok(envelope) => {
-                            trace!("Telemetry item received: {}", envelope.name);
-                            items.push(envelope);
-                            continue
-                        },
-                        Err(err) => {
-                            error!("event channel closed: {}", err);
-                            return m.transition(TerminateRequested).as_enum()
-                        }
-                    }
-                }
                 recv(self.command_receiver) -> command => {
                     match command {
                         Ok(command) => {
@@ -172,6 +159,11 @@ impl Worker {
             m.trigger().unwrap()
         );
 
+        // read items from a channel
+        let pending_items = self.event_receiver.try_iter();
+        items.extend(pending_items);
+
+        // submit items to the server if any
         if items.is_empty() {
             debug!("Nothing to send. Continue to wait");
             m.transition(ItemsSentAndContinue).as_enum()

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -79,7 +79,6 @@ manual_timeout_test! {
 
 manual_timeout_test! {
     fn it_sends_telemetry_items_in_several_batches() {
-        let _ = env_logger::builder().is_test(true).filter_level(log::LevelFilter::Debug).try_init();
         let server = server().status(StatusCode::OK).status(StatusCode::OK).create();
 
         let client = create_client(server.url());

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code, unused_variables)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -64,6 +63,8 @@ manual_timeout_test! {
 
         // verify 1 items is sent after first interval expired
         let receiver = server.requests();
+
+        // "wait" until interval expired
         timeout::expire();
         assert_matches!(receiver.recv_timeout(Duration::from_millis(500)), Ok(_));
 
@@ -86,6 +87,8 @@ manual_timeout_test! {
         for i in 0..10 {
             client.track_event(format!("--event {}--", i));
         }
+
+        // "wait" until interval expired
         timeout::expire();
 
         // send next 5 items and then interval expired
@@ -93,6 +96,7 @@ manual_timeout_test! {
             client.track_event(format!("--event {}--", i));
         }
 
+        // "wait" until next interval expired
         timeout::expire();
 
         // verify that 2 requests has been send
@@ -221,10 +225,10 @@ manual_timeout_test! {
             client.track_event(format!("--event {}--", i));
         }
 
+        // "wait" until interval expired
         timeout::expire();
 
         // "wait" until retry logic handled
-        std::thread::sleep(Duration::from_millis(300));
         timeout::expire();
 
         // verify there are 2 identical requests
@@ -282,10 +286,10 @@ manual_timeout_test! {
             client.track_event(format!("--event {}--", i));
         }
 
+        // "wait" until interval expired
         timeout::expire();
 
         // "wait" until retry logic handled
-        std::thread::sleep(Duration::from_millis(300));
         timeout::expire();
 
         // verify it sends a first request with all items

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -79,6 +79,7 @@ manual_timeout_test! {
 
 manual_timeout_test! {
     fn it_sends_telemetry_items_in_2_batches() {
+        let _ = env_logger::builder().is_test(true).filter_level(log::LevelFilter::Debug).try_init();
         let server = server().status(StatusCode::OK).status(StatusCode::OK).create();
 
         let client = create_client(server.url());

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -90,6 +90,12 @@ manual_timeout_test! {
         }
 
         // "wait" until interval expired
+        // TODO delete this hack
+        // this thread::sleep is required only to await while all items sent in previous step be
+        // processed buy internal worker. Now it contains multiple channels that worker loop reads
+        // events from one by one sometimes it picks expiration command instead of items sent
+        // before.
+        std::thread::sleep(Duration::from_millis(300));
         timeout::expire();
 
         // send next 5 items and then interval expired

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -92,12 +92,7 @@ manual_timeout_test! {
         for i in 10..15 {
             client.track_event(format!("--event {}--", i));
         }
-        // TODO delete this hack
-        // this thread::sleep is required only to await while all items sent in previous step be
-        // processed buy internal worker. Now it contains multiple channels that worker loop reads
-        // events from one by one sometimes it picks expiration command instead of items sent
-        // before.
-        std::thread::sleep(Duration::from_millis(300));
+
         timeout::expire();
 
         // verify that 2 requests has been send
@@ -126,13 +121,6 @@ manual_timeout_test! {
         for i in 0..15 {
             client.track_event(format!("--event {}--", i));
         }
-
-        // TODO delete this hack
-        // this thread::sleep is required only to await while all items sent in previous step be
-        // processed buy internal worker. Now it contains multiple channels that worker loop reads
-        // events from one by one sometimes it picks expiration command instead of items sent
-        // before.
-        std::thread::sleep(Duration::from_millis(300));
 
         // force client to send all items to the server
         client.flush_channel();
@@ -165,13 +153,6 @@ manual_timeout_test! {
             client.track_event(format!("--event {}--", i));
         }
 
-        // TODO delete this hack
-        // this thread::sleep is required only to await while all items sent in previous step be
-        // processed buy internal worker. Now it contains multiple channels that worker loop reads
-        // events from one by one sometimes it picks expiration command instead of items sent
-        // before.
-        std::thread::sleep(Duration::from_millis(300));
-
         // drop client
         drop(client);
 
@@ -195,13 +176,6 @@ manual_timeout_test! {
         for i in 0..15 {
             client.track_event(format!("--event {}--", i));
         }
-
-        // TODO delete this hack
-        // this thread::sleep is required only to await while all items sent in previous step be
-        // processed buy internal worker. Now it contains multiple channels that worker loop reads
-        // events from one by one sometimes it picks expiration command instead of items sent
-        // before.
-        std::thread::sleep(Duration::from_millis(300));
 
         // close internal channel means that client will make an attempt to send telemetry items once
         // and then tear down submission flow
@@ -247,12 +221,6 @@ manual_timeout_test! {
             client.track_event(format!("--event {}--", i));
         }
 
-        // TODO delete this hack
-        // this thread::sleep is required only to await while all items sent in previous step be
-        // processed buy internal worker. Now it contains multiple channels that worker loop reads
-        // events from one by one sometimes it picks expiration command instead of items sent
-        // before.
-        std::thread::sleep(Duration::from_millis(300));
         timeout::expire();
 
         // "wait" until retry logic handled
@@ -314,12 +282,6 @@ manual_timeout_test! {
             client.track_event(format!("--event {}--", i));
         }
 
-        // TODO delete this hack
-        // this thread::sleep is required only to await while all items sent in previous step be
-        // processed buy internal worker. Now it contains multiple channels that worker loop reads
-        // events from one by one sometimes it picks expiration command instead of items sent
-        // before.
-        std::thread::sleep(Duration::from_millis(300));
         timeout::expire();
 
         // "wait" until retry logic handled

--- a/appinsights/tests/telemetry.rs
+++ b/appinsights/tests/telemetry.rs
@@ -38,8 +38,6 @@ fn it_tracks_all_telemetry_items() {
         true,
     );
 
-    // TODO make something more reliable
-    std::thread::sleep(Duration::from_millis(300));
     ai.close_channel();
 
     logger::wait_until(&entries, "Successfully sent 6 items", Duration::from_secs(10));


### PR DESCRIPTION
The worker has 2 channels: 
1. events channel where all telemetry items go
2. commands channel where Terminate, Flush, Close commands go

In a waiting state, worker awaited either one of the events happened: timeout expired, new command arrived, new telemetry item received. `select!` macros doesn't guarantee any ordering and sometimes command processed out of order, even there are pending telemetry items available that were submitter *before* command. 

It seems like receiving items in the waiting step is a redundant operation and items receiving may happen on sending step right before actual submission. It means that potentially several telemetry items that were sent into channel *after* command submitted may slip into the pending items list. Probably it will not make any harm; otherwise, the timestamp should be assigned to any message that goes in either of channels.