### PR TITLE
Improve ergonomics of user facing telemetry methods

### DIFF
--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -355,6 +355,8 @@ manual_timeout_test! {
     }
 }
 
+// TODO Check case when all retries exhausted. Pending items should not be lost
+
 fn create_client(endpoint: &str) -> TelemetryClient<InMemoryChannel> {
     let config = TelemetryConfig::builder()
         .i_key("instrumentation key")

--- a/appinsights/src/client/integration_tests.rs
+++ b/appinsights/src/client/integration_tests.rs
@@ -45,7 +45,7 @@ manual_timeout_test! {
         let server = server().status(StatusCode::OK).create();
 
         let client = create_client(server.url());
-        client.track_event("--event--".into());
+        client.track_event("--event--");
 
         timeout::expire();
 
@@ -60,7 +60,7 @@ manual_timeout_test! {
         let server = server().status(StatusCode::OK).create();
 
         let client = create_client(server.url());
-        client.track_event("--event--".into());
+        client.track_event("--event--");
 
         // verify 1 items is sent after first interval expired
         let receiver = server.requests();

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -209,7 +209,7 @@ where
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
     /// use appinsights::telemetry::AggregateMetricTelemetry;
     ///
-    /// let mut telemetry = AggregateMetricTelemetry::new("device_message_latency_per_min".into());
+    /// let mut telemetry = AggregateMetricTelemetry::new("device_message_latency_per_min");
     /// telemetry.stats_mut().add_data(&[113.0, 250.0, 316.0]);
     ///
     /// client.track(telemetry);

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -105,9 +105,9 @@ where
     /// ```rust, no_run
     /// # use appinsights::TelemetryClient;
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
-    /// client.track_event("app is running".to_string());
+    /// client.track_event("app is running");
     /// ```
-    pub fn track_event(&self, name: String) {
+    pub fn track_event(&self, name: impl Into<String>) {
         let event = EventTelemetry::new(name);
         self.track(event)
     }
@@ -120,9 +120,9 @@ where
     /// # use appinsights::TelemetryClient;
     /// # use appinsights::telemetry::SeverityLevel;
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
-    /// client.track_trace("Unable to connect to a gateway".to_string(), SeverityLevel::Warning);
+    /// client.track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
     /// ```
-    pub fn track_trace(&self, message: String, severity: SeverityLevel) {
+    pub fn track_trace(&self, message: impl Into<String>, severity: SeverityLevel) {
         let event = TraceTelemetry::new(message, severity);
         self.track(event)
     }
@@ -136,9 +136,9 @@ where
     /// # use appinsights::TelemetryClient;
     /// # use appinsights::telemetry::SeverityLevel;
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
-    /// client.track_metric("gateway_latency_ms".to_string(), 113.0);
+    /// client.track_metric("gateway_latency_ms", 113.0);
     /// ```    
-    pub fn track_metric(&self, name: String, value: f64) {
+    pub fn track_metric(&self, name: impl Into<String>, value: f64) {
         let event = MetricTelemetry::new(name, value);
         self.track(event)
     }
@@ -154,9 +154,9 @@ where
     /// use std::time::Duration;
     ///
     /// let uri: Uri = "https://api.github.com/dmolokanov/appinsights-rs".parse().unwrap();
-    /// client.track_request(Method::GET, uri, Duration::from_millis(100), "200".to_string());
+    /// client.track_request(Method::GET, uri, Duration::from_millis(100), "200");
     /// ```
-    pub fn track_request(&self, method: Method, uri: Uri, duration: Duration, response_code: String) {
+    pub fn track_request(&self, method: Method, uri: Uri, duration: Duration, response_code: impl Into<String>) {
         let event = RequestTelemetry::new(method, uri, duration, response_code);
         self.track(event)
     }
@@ -169,13 +169,19 @@ where
     /// # use appinsights::TelemetryClient;
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
     /// client.track_remote_dependency(
-    ///     "GET https://api.github.com/dmolokanov/appinsights-rs".to_string(),
-    ///     "HTTP".to_string(),
-    ///     "api.github.com".to_string(),
+    ///     "GET https://api.github.com/dmolokanov/appinsights-rs",
+    ///     "HTTP",
+    ///     "api.github.com",
     ///     true
     /// );
     /// ```
-    pub fn track_remote_dependency(&self, name: String, dependency_type: String, target: String, success: bool) {
+    pub fn track_remote_dependency(
+        &self,
+        name: impl Into<String>,
+        dependency_type: impl Into<String>,
+        target: impl Into<String>,
+        success: bool,
+    ) {
         let event = RemoteDependencyTelemetry::new(name, dependency_type, Default::default(), target, success);
         self.track(event)
     }
@@ -190,12 +196,12 @@ where
     /// use std::time::Duration;
     ///
     /// client.track_availability(
-    ///     "GET https://api.github.com/dmolokanov/appinsights-rs".to_string(),
+    ///     "GET https://api.github.com/dmolokanov/appinsights-rs",
     ///     Duration::from_millis(100),
     ///     true
     /// );
     /// ```
-    pub fn track_availability(&self, name: String, duration: Duration, success: bool) {
+    pub fn track_availability(&self, name: impl Into<String>, duration: Duration, success: bool) {
         let event = AvailabilityTelemetry::new(name, duration, success);
         self.track(event)
     }
@@ -239,7 +245,7 @@ where
     /// // send heartbeats while application is running
     /// let running = true;
     /// while running {
-    ///     client.track_event("app is running".to_string());
+    ///     client.track_event("app is running");
     /// }
     ///
     /// // wait until pending telemetry is sent at most once and tear down submission flow
@@ -265,7 +271,7 @@ where
     /// // send heartbeats while application is running
     /// let running = true;
     /// while running {
-    ///     client.track_event("app is running".to_string());
+    ///     client.track_event("app is running");
     ///     counter += 1;
     ///
     ///     // if the rate is bigger than submission interval you can make sure that data is

--- a/appinsights/src/lib.rs
+++ b/appinsights/src/lib.rs
@@ -36,7 +36,7 @@
 //! let client = TelemetryClient::new("<instrumentation key>".to_string());
 //!
 //! // send event telemetry to the Application Insights server
-//! client.track_event("Application started".to_string());
+//! client.track_event("Application started");
 //! ```
 //!
 //! If you need more control over the client's behavior, you can create a new instance of
@@ -61,7 +61,7 @@
 //! let client = TelemetryClient::from_config(config);
 //!
 //! // send trace telemetry to the Application Insights server
-//! client.track_trace("A database error occurred".to_string(), SeverityLevel::Warning);
+//! client.track_trace("A database error occurred", SeverityLevel::Warning);
 //! ```
 //!
 //! ## Telemetry submission

--- a/appinsights/src/lib.rs
+++ b/appinsights/src/lib.rs
@@ -110,7 +110,7 @@
 //!     Method::GET,
 //!     "https://example.com/main.html".parse().unwrap(),
 //!     Duration::from_secs(2),
-//!     "200".into(),
+//!     "200",
 //! );
 //!
 //! // set the account id context tag

--- a/appinsights/src/telemetry/availability.rs
+++ b/appinsights/src/telemetry/availability.rs
@@ -19,7 +19,7 @@ use crate::uuid::Uuid;
 ///
 /// // create a telemetry item
 /// let mut telemetry = AvailabilityTelemetry::new(
-///     "PING https://api.github.com/dmolokanov/appinsights-rs".to_string(),
+///     "PING https://api.github.com/dmolokanov/appinsights-rs",
 ///      Duration::from_secs(2),
 ///      true,
 /// );
@@ -67,10 +67,10 @@ pub struct AvailabilityTelemetry {
 
 impl AvailabilityTelemetry {
     /// Creates a new availability telemetry item with the specified test name, duration and success code.
-    pub fn new(name: String, duration: StdDuration, success: bool) -> Self {
+    pub fn new(name: impl Into<String>, duration: StdDuration, success: bool) -> Self {
         Self {
             id: Option::default(),
-            name,
+            name: name.into(),
             duration: duration.into(),
             run_location: Option::default(),
             message: Option::default(),
@@ -163,11 +163,8 @@ mod tests {
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = AvailabilityTelemetry::new(
-            "GET https://example.com/main.html".into(),
-            StdDuration::from_secs(2),
-            true,
-        );
+        let mut telemetry =
+            AvailabilityTelemetry::new("GET https://example.com/main.html", StdDuration::from_secs(2), true);
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
         telemetry.measurements_mut().insert("latency".into(), 200.0);
 
@@ -211,11 +208,8 @@ mod tests {
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = AvailabilityTelemetry::new(
-            "GET https://example.com/main.html".into(),
-            StdDuration::from_secs(2),
-            true,
-        );
+        let mut telemetry =
+            AvailabilityTelemetry::new("GET https://example.com/main.html", StdDuration::from_secs(2), true);
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 
         let envelop = Envelope::from((context, telemetry));

--- a/appinsights/src/telemetry/event.rs
+++ b/appinsights/src/telemetry/event.rs
@@ -14,7 +14,7 @@ use crate::time;
 /// use appinsights::telemetry::{Telemetry, EventTelemetry};
 ///
 /// // create a telemetry item
-/// let mut telemetry = EventTelemetry::new("Starting data processing".to_string());
+/// let mut telemetry = EventTelemetry::new("Starting data processing");
 ///
 /// // attach custom properties, measurements and context tags
 /// telemetry.properties_mut().insert("component".to_string(), "data_processor".to_string());
@@ -43,9 +43,9 @@ pub struct EventTelemetry {
 
 impl EventTelemetry {
     /// Creates an event telemetry item with specified name.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
-            name,
+            name: name.into(),
             timestamp: time::now(),
             properties: Properties::default(),
             tags: ContextTags::default(),
@@ -127,7 +127,7 @@ mod tests {
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = EventTelemetry::new("test".into());
+        let mut telemetry = EventTelemetry::new("test");
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
         telemetry.measurements_mut().insert("value".into(), 5.0);
 
@@ -168,7 +168,7 @@ mod tests {
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = EventTelemetry::new("test".into());
+        let mut telemetry = EventTelemetry::new("test");
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 
         let envelop = Envelope::from((context, telemetry));

--- a/appinsights/src/telemetry/metric/aggregation.rs
+++ b/appinsights/src/telemetry/metric/aggregation.rs
@@ -16,7 +16,7 @@ use crate::time;
 /// use appinsights::telemetry::{Telemetry, AggregateMetricTelemetry};
 ///
 /// // create a telemetry item
-/// let mut telemetry = AggregateMetricTelemetry::new("temp_sensor".into());
+/// let mut telemetry = AggregateMetricTelemetry::new("temp_sensor");
 /// telemetry.stats_mut().add_data(&[50.0, 53.1, 56.4]);
 ///
 /// // assign custom properties and context tags
@@ -45,9 +45,9 @@ pub struct AggregateMetricTelemetry {
 
 impl AggregateMetricTelemetry {
     /// Creates a metric telemetry item with specified name and value.
-    pub fn new(name: String) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
-            name,
+            name: name.into(),
             stats: Stats::default(),
             timestamp: time::now(),
             properties: Properties::default(),
@@ -137,7 +137,7 @@ mod tests {
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = AggregateMetricTelemetry::new("test".into());
+        let mut telemetry = AggregateMetricTelemetry::new("test");
         telemetry.stats_mut().add_data(&[9.0, 10.0, 11.0, 7.0, 13.0]);
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
 
@@ -182,7 +182,7 @@ mod tests {
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = AggregateMetricTelemetry::new("test".into());
+        let mut telemetry = AggregateMetricTelemetry::new("test");
         telemetry.stats_mut().add_data(&[9.0, 10.0, 11.0, 7.0, 13.0]);
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 
@@ -223,7 +223,7 @@ mod tests {
         let mut stats = Stats::default();
         stats.add_data(&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
-        let mut telemetry = AggregateMetricTelemetry::new("stats".into());
+        let mut telemetry = AggregateMetricTelemetry::new("stats");
         *telemetry.stats_mut() = stats;
 
         assert!((telemetry.stats().value - 15.0).abs() < std::f64::EPSILON);
@@ -234,7 +234,7 @@ mod tests {
         let mut properties = Properties::default();
         properties.insert("name".into(), "value".into());
 
-        let mut telemetry = AggregateMetricTelemetry::new("props".into());
+        let mut telemetry = AggregateMetricTelemetry::new("props");
         *telemetry.properties_mut() = properties;
 
         assert_eq!(telemetry.properties().len(), 1);
@@ -245,7 +245,7 @@ mod tests {
         let mut tags = ContextTags::default();
         tags.insert("name".into(), "value".into());
 
-        let mut telemetry = AggregateMetricTelemetry::new("props".into());
+        let mut telemetry = AggregateMetricTelemetry::new("props");
         *telemetry.tags_mut() = tags;
 
         assert_eq!(telemetry.tags().len(), 1);

--- a/appinsights/src/telemetry/metric/measurement.rs
+++ b/appinsights/src/telemetry/metric/measurement.rs
@@ -14,7 +14,7 @@ use crate::time;
 /// use appinsights::telemetry::{Telemetry, MetricTelemetry};
 ///
 /// // create a telemetry item
-/// let mut telemetry = MetricTelemetry::new("temp_sensor".to_string(), 55.0);
+/// let mut telemetry = MetricTelemetry::new("temp_sensor", 55.0);
 ///
 /// // assign custom properties and context tags
 /// telemetry.properties_mut().insert("component".to_string(), "external_device".to_string());
@@ -42,9 +42,9 @@ pub struct MetricTelemetry {
 
 impl MetricTelemetry {
     /// Creates a metric telemetry item with specified name and value.
-    pub fn new(name: String, value: f64) -> Self {
+    pub fn new(name: impl Into<String>, value: f64) -> Self {
         Self {
-            name,
+            name: name.into(),
             value,
             timestamp: time::now(),
             properties: Properties::default(),
@@ -121,7 +121,7 @@ mod tests {
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = MetricTelemetry::new("test".into(), 123.0);
+        let mut telemetry = MetricTelemetry::new("test", 123.0);
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
 
         let envelop = Envelope::from((context, telemetry));
@@ -162,7 +162,7 @@ mod tests {
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = MetricTelemetry::new("test".into(), 123.0);
+        let mut telemetry = MetricTelemetry::new("test", 123.0);
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 
         let envelop = Envelope::from((context, telemetry));

--- a/appinsights/src/telemetry/page_view.rs
+++ b/appinsights/src/telemetry/page_view.rs
@@ -19,7 +19,7 @@ use crate::uuid::Uuid;
 ///
 /// // create a telemetry item
 /// let mut telemetry = PageViewTelemetry::new(
-///     "check github repo page".to_string(),
+///     "check github repo page",
 ///     "https://github.com/dmolokanov/appinsights-rs".parse::<Uri>().unwrap(),
 /// );
 ///
@@ -60,10 +60,10 @@ pub struct PageViewTelemetry {
 
 impl PageViewTelemetry {
     /// Creates a new page view telemetry item with the specified name and url.
-    pub fn new(name: String, uri: Uri) -> Self {
+    pub fn new(name: impl Into<String>, uri: Uri) -> Self {
         Self {
             id: Option::default(),
-            name,
+            name: name.into(),
             uri,
             duration: Option::default(),
             timestamp: time::now(),
@@ -153,8 +153,7 @@ mod tests {
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry =
-            PageViewTelemetry::new("page updated".into(), "https://example.com/main.html".parse().unwrap());
+        let mut telemetry = PageViewTelemetry::new("page updated", "https://example.com/main.html".parse().unwrap());
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
         telemetry.measurements_mut().insert("latency".into(), 200.0);
 
@@ -196,8 +195,7 @@ mod tests {
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry =
-            PageViewTelemetry::new("page updated".into(), "https://example.com/main.html".parse().unwrap());
+        let mut telemetry = PageViewTelemetry::new("page updated", "https://example.com/main.html".parse().unwrap());
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 
         let envelop = Envelope::from((context, telemetry));

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -19,10 +19,10 @@ use crate::uuid::Uuid;
 ///
 /// // create a telemetry item
 /// let mut telemetry = RemoteDependencyTelemetry::new(
-///     "GET https://api.github.com/dmolokanov/appinsights-rs".to_string(),
-///     "HTTP".into(),
+///     "GET https://api.github.com/dmolokanov/appinsights-rs",
+///     "HTTP",
 ///     Duration::from_secs(2),
-///     "api.github.com".to_string(),
+///     "api.github.com",
 ///     true,
 /// );
 ///
@@ -80,16 +80,22 @@ pub struct RemoteDependencyTelemetry {
 
 impl RemoteDependencyTelemetry {
     /// Creates a new telemetry item with specified name, dependency type, target site and success status.
-    pub fn new(name: String, dependency_type: String, duration: StdDuration, target: String, success: bool) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        dependency_type: impl Into<String>,
+        duration: StdDuration,
+        target: impl Into<String>,
+        success: bool,
+    ) -> Self {
         Self {
             id: Option::default(),
-            name,
+            name: name.into(),
             duration: duration.into(),
             result_code: Option::default(),
             success,
             data: Option::default(),
-            dependency_type,
-            target,
+            dependency_type: dependency_type.into(),
+            target: target.into(),
             timestamp: time::now(),
             properties: Properties::default(),
             tags: ContextTags::default(),
@@ -178,10 +184,10 @@ mod tests {
         context.properties_mut().insert("no-write".into(), "fail".into());
 
         let mut telemetry = RemoteDependencyTelemetry::new(
-            "GET https://example.com/main.html".into(),
-            "HTTP".into(),
+            "GET https://example.com/main.html",
+            "HTTP",
             StdDuration::from_secs(2),
-            "example.com".into(),
+            "example.com",
             true,
         );
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
@@ -229,10 +235,10 @@ mod tests {
         context.tags_mut().insert("no-write".into(), "fail".into());
 
         let mut telemetry = RemoteDependencyTelemetry::new(
-            "GET https://example.com/main.html".into(),
-            "HTTP".into(),
+            "GET https://example.com/main.html",
+            "HTTP",
             StdDuration::from_secs(2),
-            "example.com".into(),
+            "example.com",
             true,
         );
         telemetry.tags_mut().insert("no-write".into(), "ok".into());

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -26,7 +26,7 @@ use crate::uuid::{self, Uuid};
 ///     Method::GET,
 ///     "https://api.github.com/dmolokanov/appinsights-rs".parse::<Uri>().unwrap(),
 ///     Duration::from_millis(182),
-///     "200".to_string()
+///     "200"
 /// );
 ///
 /// // attach custom properties, measurements and context tags
@@ -69,7 +69,7 @@ pub struct RequestTelemetry {
 
 impl RequestTelemetry {
     /// Creates a new telemetry item for HTTP request.
-    pub fn new(method: Method, uri: Uri, duration: StdDuration, response_code: String) -> Self {
+    pub fn new(method: Method, uri: Uri, duration: StdDuration, response_code: impl Into<String>) -> Self {
         let mut authority = String::new();
         if let Some(host) = &uri.host() {
             authority.push_str(host);
@@ -90,7 +90,7 @@ impl RequestTelemetry {
             name: format!("{} {}", method, uri),
             uri,
             duration: duration.into(),
-            response_code,
+            response_code: response_code.into(),
             timestamp: time::now(),
             properties: Properties::default(),
             tags: ContextTags::default(),
@@ -193,7 +193,7 @@ mod tests {
             Method::GET,
             "https://example.com/main.html".parse().unwrap(),
             StdDuration::from_secs(2),
-            "200".into(),
+            "200",
         );
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
         telemetry.measurements_mut().insert("latency".into(), 200.0);
@@ -245,7 +245,7 @@ mod tests {
             Method::GET,
             "https://example.com/main.html".parse().unwrap(),
             StdDuration::from_secs(2),
-            "200".into(),
+            "200",
         );
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -15,7 +15,7 @@ use crate::time;
 /// use appinsights::telemetry::{TraceTelemetry, SeverityLevel, Telemetry};
 ///
 /// // create a telemetry item
-/// let mut telemetry = TraceTelemetry::new("Starting data processing".to_string(), SeverityLevel::Information);
+/// let mut telemetry = TraceTelemetry::new("Starting data processing", SeverityLevel::Information);
 ///
 /// // attach custom properties, measurements and context tags
 /// telemetry.properties_mut().insert("component".to_string(), "data_processor".to_string());
@@ -47,9 +47,9 @@ pub struct TraceTelemetry {
 
 impl TraceTelemetry {
     /// Creates an event telemetry item with specified name.
-    pub fn new(message: String, severity: SeverityLevel) -> Self {
+    pub fn new(message: impl Into<String>, severity: SeverityLevel) -> Self {
         Self {
-            message,
+            message: message.into(),
             severity,
             timestamp: time::now(),
             properties: Properties::default(),
@@ -162,7 +162,7 @@ mod tests {
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = TraceTelemetry::new("message".into(), SeverityLevel::Information);
+        let mut telemetry = TraceTelemetry::new("message", SeverityLevel::Information);
         telemetry.properties_mut().insert("no-write".into(), "ok".into());
         telemetry.measurements_mut().insert("value".into(), 5.0);
 
@@ -204,7 +204,7 @@ mod tests {
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 
-        let mut telemetry = TraceTelemetry::new("message".into(), SeverityLevel::Information);
+        let mut telemetry = TraceTelemetry::new("message", SeverityLevel::Information);
         telemetry.tags_mut().insert("no-write".into(), "ok".into());
 
         let envelop = Envelope::from((context, telemetry));

--- a/appinsights/tests/telemetry.rs
+++ b/appinsights/tests/telemetry.rs
@@ -15,9 +15,9 @@ fn it_tracks_all_telemetry_items() {
     let i_key = env::var("APPINSIGHTS_INSTRUMENTATIONKEY").expect("Set APPINSIGHTS_INSTRUMENTATIONKEY first");
     let ai = TelemetryClient::new(i_key);
 
-    ai.track_event("event happened".into());
-    ai.track_trace("Unable to connect to a gateway".to_string(), SeverityLevel::Warning);
-    ai.track_metric("gateway_latency_ms".to_string(), 113.0);
+    ai.track_event("event happened");
+    ai.track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
+    ai.track_metric("gateway_latency_ms", 113.0);
     ai.track_request(
         Method::GET,
         "https://api.github.com/dmolokanov/appinsights-rs"
@@ -27,13 +27,13 @@ fn it_tracks_all_telemetry_items() {
         "200".to_string(),
     );
     ai.track_remote_dependency(
-        "GET https://api.github.com/dmolokanov/appinsights-rs".to_string(),
-        "HTTP".to_string(),
-        "api.github.com".to_string(),
+        "GET https://api.github.com/dmolokanov/appinsights-rs",
+        "HTTP",
+        "api.github.com",
         true,
     );
     ai.track_availability(
-        "GET https://api.github.com/dmolokanov/appinsights-rs".to_string(),
+        "GET https://api.github.com/dmolokanov/appinsights-rs",
         Duration::from_secs(2),
         true,
     );


### PR DESCRIPTION
Replace signature of user-facing methods in a way that instead accepting owned `String` it takes `Into<String>`

Closes #14 