### PR TITLE
Made the internal worker async, fixed a panic when starting appinsights in an already running tokio context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,12 +311,9 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -636,15 +633,6 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1183,7 +1171,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1551,7 +1538,6 @@ dependencies = [
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)" = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,17 @@ dependencies = [
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1600,6 +1611,7 @@ dependencies = [
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
+"checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 "checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"

--- a/appinsights/Cargo.toml
+++ b/appinsights/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 chrono = "0.4"
 http = "0.2.1"
 uuid = { version = "0.8", features = ["v4"], default-features = false }
-reqwest = { version = "0.10", features = ["blocking", "json", "native-tls"], default-features = false }
+reqwest = { version = "0.10", features = ["json", "native-tls"], default-features = false }
 log = "0.4"
 crossbeam-channel = "0.4"
 sm = "0.9"

--- a/appinsights/Cargo.toml
+++ b/appinsights/Cargo.toml
@@ -26,6 +26,7 @@ crossbeam-channel = "0.4"
 sm = "0.9"
 paste = "0.1"
 hostname = "0.3"
+tokio = { version = "0.2.21", default-features = false }
 
 [dev-dependencies]
 test-case = "1.0"
@@ -34,5 +35,5 @@ mockito = { version = "0.26.0", default-features = false }
 lazy_static = "1.4"
 matches = "0.1"
 hyper = { version = "0.13.2" }
-tokio = { version = "0.2.21", default-features = false }
 futures = { version = "0.3.4", default-features = false }
+tokio = { version = "0.2.21", default-features = false, features = ["rt-core", "macros"] }

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -307,6 +307,11 @@ mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    async fn it_should_not_crash_in_tokio_context() {
+        let _client = TelemetryClient::new("key".into());
+    }
+
     #[test]
     fn it_enabled_by_default() {
         let client = TelemetryClient::new("key".into());


### PR DESCRIPTION
There are two scenarios that the crate can be in when a Worker is created:
1. The tokio runtime is already running, simply calling `tokio::spawn(async move { worker.run().await });` works
2. The tokio runtime is not already running. In this case we have to set up a new tokio runtime, spawn a new OS thread, and continuously run on there.

Shutting down the second scenario is easy (wait on the `std::thread::JoinHandle`). However, there [does not seem to be such a method on tokio::task::JoinHandle](https://docs.rs/tokio/0.2.21/tokio/task/struct.JoinHandle.html). I'm not sure what to do in this case.

Closes #82 