### PR TITLE
Made the operation_Name default to the name of the request

### DIFF
--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -209,7 +209,11 @@ mod tests {
             name: "Microsoft.ApplicationInsights.Request".into(),
             time: "2019-01-02T03:04:05.800Z".into(),
             i_key: Some("instrumentation".into()),
-            tags: Some(BTreeMap::default()),
+            tags: Some({
+                let mut tags = BTreeMap::default();
+                tags.insert("ai.operation.name".into(), "GET https://example.com/main.html".into());
+                tags
+            }),
             data: Some(Base::Data(Data::RequestData(RequestData {
                 id: "910b414a-f368-4b3a-aff6-326632aac566".into(),
                 name: Some("GET https://example.com/main.html".into()),
@@ -261,6 +265,7 @@ mod tests {
             i_key: Some("instrumentation".into()),
             tags: Some({
                 let mut tags = BTreeMap::default();
+                tags.insert("ai.operation.name".into(), "GET https://example.com/main.html".into());
                 tags.insert("test".into(), "ok".into());
                 tags.insert("no-write".into(), "ok".into());
                 tags

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -85,15 +85,20 @@ impl RequestTelemetry {
             .build()
             .unwrap_or(uri);
 
+        let name = format!("{} {}", method, uri);
+
+        let mut tags = ContextTags::default();
+        tags.operation_mut().set_name(name.clone());
+
         Self {
             id: uuid::new(),
-            name: format!("{} {}", method, uri),
+            name,
             uri,
             duration: duration.into(),
             response_code: response_code.into(),
             timestamp: time::now(),
             properties: Properties::default(),
-            tags: ContextTags::default(),
+            tags,
             measurements: Measurements::default(),
         }
     }


### PR DESCRIPTION
In C#, application insights will automatically set the `operation_Name` to e.g. `GET /`

With appinsights-rs, the `operation_Name` is empty by default. An empty `operation_name` does not show up in the application insights dashboard. I think it is most often desired to set `operation_Name` to the  value of `name` that is set already.

Before:

![image](https://user-images.githubusercontent.com/2743142/85783006-43f5a100-b727-11ea-8da3-4b4842bcb632.png)

After:

![image](https://user-images.githubusercontent.com/2743142/85783160-5a9bf800-b727-11ea-90d8-e3b7be445f62.png)
