### PR TITLE
Remove unneccessary to_vec() calls

### DIFF
--- a/appinsights/src/channel/memory.rs
+++ b/appinsights/src/channel/memory.rs
@@ -20,8 +20,8 @@ pub struct InMemoryChannel {
 impl InMemoryChannel {
     /// Creates a new instance of in-memory channel and starts a submission routine.
     pub fn new(config: &TelemetryConfig) -> Self {
-        let (event_sender, event_receiver) = unbounded::<Envelope>();
-        let (command_sender, command_receiver) = unbounded::<Command>();
+        let (event_sender, event_receiver) = unbounded();
+        let (command_sender, command_receiver) = unbounded();
 
         let worker = Worker::new(
             Transmitter::new(config.endpoint()),


### PR DESCRIPTION
After each successful attempt to submit events to the server, it allocates a new `Vec` for items to retry even when all events to be re-sent. We can do better by retaining only those items that suppose to be re-sent.