### PR TITLE
Allow updating the timestamp of an already created item and also updating of few other fields.

### DIFF
--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -376,6 +376,10 @@ mod tests {
             unimplemented!()
         }
 
+        fn set_timestamp(&mut self, _: impl Into<DateTime<Utc>>) {
+            unimplemented!()
+        }
+
         fn properties(&self) -> &Properties {
             unimplemented!()
         }

--- a/appinsights/src/telemetry/availability.rs
+++ b/appinsights/src/telemetry/availability.rs
@@ -94,12 +94,27 @@ impl AvailabilityTelemetry {
     pub fn measurements_mut(&mut self) -> &mut Measurements {
         &mut self.measurements
     }
+
+    /// Sets the run_location field on the availability telemetry item
+    pub fn set_run_location(&mut self, location: impl Into<String>) {
+        self.run_location = Some(location.into());
+    }
+
+    /// Sets the run_location field on the availability telemetry item
+    pub fn set_message(&mut self, message: impl Into<String>) {
+        self.message = Some(message.into());
+    }
 }
 
 impl Telemetry for AvailabilityTelemetry {
     /// Returns the time when this telemetry was measured.
     fn timestamp(&self) -> DateTime<Utc> {
         self.timestamp
+    }
+
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
     }
 
     /// Returns custom properties to submit with the telemetry item.

--- a/appinsights/src/telemetry/event.rs
+++ b/appinsights/src/telemetry/event.rs
@@ -73,6 +73,11 @@ impl Telemetry for EventTelemetry {
         self.timestamp
     }
 
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
+    }
+
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties {
         &self.properties

--- a/appinsights/src/telemetry/metric/aggregation.rs
+++ b/appinsights/src/telemetry/metric/aggregation.rs
@@ -75,6 +75,11 @@ impl Telemetry for AggregateMetricTelemetry {
         self.timestamp
     }
 
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
+    }
+
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties {
         &self.properties

--- a/appinsights/src/telemetry/metric/measurement.rs
+++ b/appinsights/src/telemetry/metric/measurement.rs
@@ -62,6 +62,11 @@ impl Telemetry for MetricTelemetry {
         self.timestamp
     }
 
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
+    }
+
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties {
         &self.properties

--- a/appinsights/src/telemetry/mod.rs
+++ b/appinsights/src/telemetry/mod.rs
@@ -32,6 +32,8 @@ pub trait Telemetry {
     /// Returns the time when this telemetry was measured.
     fn timestamp(&self) -> DateTime<Utc>;
 
+    /// Sets timestamp
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>);
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties;
 

--- a/appinsights/src/telemetry/page_view.rs
+++ b/appinsights/src/telemetry/page_view.rs
@@ -93,6 +93,11 @@ impl Telemetry for PageViewTelemetry {
         self.timestamp
     }
 
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
+    }
+
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties {
         &self.properties

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -146,12 +146,27 @@ impl RemoteDependencyTelemetry {
     pub fn set_id(&mut self, id: impl Into<String>) {
         self.id = Some(id.into());
     }
+
+    /// Sets the result code of a dependency call.
+    pub fn set_result_code(&mut self, result_code: impl Into<String>) {
+        self.result_code = Some(result_code.into())
+    }
+
+    /// Command initiated by this dependency call.
+    pub fn set_data(&mut self, data: impl Into<String>) {
+        self.data = Some(data.into())
+    }
 }
 
 impl Telemetry for RemoteDependencyTelemetry {
     /// Returns the time when this telemetry was measured.
     fn timestamp(&self) -> DateTime<Utc> {
         self.timestamp
+    }
+
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
     }
 
     /// Returns custom properties to submit with the telemetry item.

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -165,6 +165,11 @@ impl Telemetry for RequestTelemetry {
         self.timestamp
     }
 
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
+    }
+
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties {
         &self.properties

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -78,6 +78,11 @@ impl Telemetry for TraceTelemetry {
         self.timestamp
     }
 
+    /// Update the event timestamp after the item was created.
+    fn set_timestamp(&mut self, timestamp: impl Into<DateTime<Utc>>) {
+        self.timestamp = timestamp.into()
+    }
+
     /// Returns custom properties to submit with the telemetry item.
     fn properties(&self) -> &Properties {
         &self.properties


### PR DESCRIPTION
Right now when a new telemetry item is created the timestamp is set to `now`, but in some cases, this might have been an event that happened earlier.