### PR TITLE
address clippy::needless_borrow warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all --tests --bins --examples
+        args: --all --tests --bins --examples -- -A clippy::enum_variant_names
 
     - name: check
       uses: actions-rs/cargo@v1

--- a/appinsights-contracts-codegen/src/ast/fields.rs
+++ b/appinsights-contracts-codegen/src/ast/fields.rs
@@ -52,7 +52,7 @@ impl Field {
 
     pub fn optional(&self) -> Option<&Type> {
         if let Some(type_) = self.field_type.nullable() {
-            Some(Field::unwrap_option(&type_))
+            Some(Field::unwrap_option(type_))
         } else if self.field_modifier == FieldModifier::Optional {
             Some(Field::unwrap_option(&self.field_type))
         } else {

--- a/appinsights-contracts-codegen/src/compiler/generator/enums.rs
+++ b/appinsights-contracts-codegen/src/compiler/generator/enums.rs
@@ -7,7 +7,7 @@ pub struct EnumGenerator {
 
 impl EnumGenerator {
     pub fn new(name: &str) -> Self {
-        let mut declaration = codegen::Enum::new(&name);
+        let mut declaration = codegen::Enum::new(name);
         declaration
             .derive("Debug")
             .derive("Clone")

--- a/appinsights-contracts-codegen/src/compiler/generator/structs.rs
+++ b/appinsights-contracts-codegen/src/compiler/generator/structs.rs
@@ -11,7 +11,7 @@ pub struct StructGenerator {
 
 impl StructGenerator {
     pub fn new(name: &str) -> Self {
-        let mut declaration = codegen::Struct::new(&name);
+        let mut declaration = codegen::Struct::new(name);
         declaration
             .derive("Debug")
             .derive("Clone")

--- a/appinsights-contracts-codegen/src/compiler/mod.rs
+++ b/appinsights-contracts-codegen/src/compiler/mod.rs
@@ -18,7 +18,7 @@ pub fn compile_all(input_dir: PathBuf, output_dir: PathBuf) -> Result<()> {
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
         .map(|path| Module::try_from((path, output_dir.clone())).expect("unable to read module path"))
         .collect();
-    modules.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+    modules.sort_by(|a, b| a.file_name().cmp(b.file_name()));
 
     compile_files(modules.iter())?;
     compile_package(modules.iter(), &output_dir.join("mod.rs"))?;
@@ -40,7 +40,7 @@ fn compile_files<'a>(modules: impl Iterator<Item = &'a Module>) -> Result<()> {
 
 fn compile(module: &Module) -> Result<()> {
     let parser = Parser::default();
-    let schema = parser.parse(&module.source_path())?;
+    let schema = parser.parse(module.source_path())?;
 
     let mut generator = SchemaGenerator::new();
     generator.visit_schema(&schema);


### PR DESCRIPTION
This addresses the `needless_borrow` warnings that are appearing in CI.

Additionally, this disables the lint `enum_variant_names` as this primarily alerts on generated code from the appinsights contracts codegen output.