### PR TITLE
Derive from `Clone` for `TelemetryConfig`

### DIFF
--- a/appinsights/src/config.rs
+++ b/appinsights/src/config.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 ///     .interval(Duration::from_secs(5))
 ///     .build();
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TelemetryConfig {
     /// Instrumentation key for the client.
     i_key: String,


### PR DESCRIPTION
Just simply adds a `Clone` derivation for the telemetry config, since this came up in my use of this library.