### PR TITLE
Make TelemetryClient Send + Sync

### DIFF
--- a/appinsights/src/channel/mod.rs
+++ b/appinsights/src/channel/mod.rs
@@ -14,7 +14,7 @@ use crate::contracts::Envelope;
 /// An implementation of [TelemetryChannel](trait.TelemetryChannel.html) is responsible for queueing
 /// and periodically submitting telemetry events.
 #[async_trait]
-pub trait TelemetryChannel {
+pub trait TelemetryChannel: Send + Sync {
     /// Queues a single telemetry item.
     fn send(&self, envelop: Envelope);
 


### PR DESCRIPTION
By declaring TelemetryChannel trait as Send + Sync, TelemetryClient will also be Send + Sync, therefore making it possible to pass between threads.