### PR TITLE
Add timeout directive to `reqwest::Client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,9 +54,12 @@ dependencies = [
  "env_logger",
  "futures-channel",
  "futures-util",
+ "graceful-shutdown",
  "hostname",
  "http",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "lazy_static",
  "log",
  "matches",
@@ -53,6 +71,7 @@ dependencies = [
  "sm",
  "test-case",
  "tokio",
+ "tower 0.5.0",
  "uuid",
 ]
 
@@ -61,7 +80,7 @@ name = "appinsights-contracts-codegen"
 version = "0.1.0"
 dependencies = [
  "codegen",
- "heck 0.4.0",
+ "heck 0.5.0",
  "serde",
  "serde_json",
  "structopt",
@@ -69,13 +88,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.103",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -84,7 +103,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -96,10 +115,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.1"
+name = "backtrace"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -114,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,9 +161,12 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -233,8 +276,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "scratch",
  "syn 1.0.103",
 ]
@@ -251,25 +294,16 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -310,9 +344,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -328,27 +362,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -358,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -368,22 +396,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.15"
+name = "gimli"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "graceful-shutdown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a144da08f7198ddd8b3bebccacda0db4fff19bdb5866ef1ee34184adfe9a7a"
 dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -403,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -417,21 +441,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
+name = "hermit-abi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -440,12 +470,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -469,52 +511,76 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
+ "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -543,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -578,9 +644,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -599,9 +665,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "link-cplusplus"
@@ -624,18 +690,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matches"
@@ -656,15 +713,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mio"
-version = "0.8.5"
+name = "miniz_oxide"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
- "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -705,20 +771,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
+name = "object"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
- "hermit-abi",
- "libc",
+ "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
@@ -741,8 +806,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
 ]
 
@@ -796,15 +861,35 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -819,14 +904,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
  "version_check",
 ]
@@ -837,8 +931,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "version_check",
 ]
 
@@ -853,11 +947,59 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -871,11 +1013,41 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
- "proc-macro2 1.0.47",
+ "proc-macro2 1.0.86",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -915,21 +1087,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -938,11 +1110,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -952,43 +1127,75 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustls"
-version = "0.20.7"
+name = "rustc-demangle"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
- "sct",
- "webpki",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1020,16 +1227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,22 +1251,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.103",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1094,6 +1291,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -1126,25 +1329,25 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1171,10 +1374,16 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1193,9 +1402,35 @@ version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1238,8 +1473,8 @@ checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
 dependencies = [
  "cfg-if",
  "proc-macro-error",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
 ]
 
@@ -1250,6 +1485,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1269,31 +1524,29 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.103",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1308,28 +1561,49 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
- "webpki",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.4"
+name = "tower"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "bytes",
  "futures-core",
- "futures-sink",
+ "futures-util",
+ "pin-project",
  "pin-project-lite",
  "tokio",
- "tracing",
+ "tower-layer",
+ "tower-service",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b837f86b25d7c0d7988f00a54e74739be6477f2aac6201b8f429a7569991b7"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -1365,9 +1639,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -1404,15 +1678,15 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1421,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -1481,8 +1755,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
@@ -1505,7 +1779,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote 1.0.21",
+ "quote 1.0.37",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1515,8 +1789,8 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
  "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -1539,22 +1813,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
 dependencies = [
- "webpki",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1589,6 +1853,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,13 +1920,47 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.0",
  "windows_aarch64_msvc 0.42.0",
  "windows_i686_gnu 0.42.0",
  "windows_i686_msvc 0.42.0",
  "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.0",
  "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1621,6 +1968,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1635,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +2004,18 @@ name = "windows_i686_gnu"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1659,6 +2030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,10 +2048,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1689,10 +2078,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
+name = "windows_x86_64_msvc"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "winapi",
+ "byteorder",
+ "zerocopy-derive",
 ]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.1",
 ]

--- a/appinsights-contracts-codegen/Cargo.toml
+++ b/appinsights-contracts-codegen/Cargo.toml
@@ -9,4 +9,4 @@ codegen = "0.2"
 structopt = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-heck = "0.4"
+heck = "0.5"

--- a/appinsights-contracts-codegen/src/compiler/generator/packages.rs
+++ b/appinsights-contracts-codegen/src/compiler/generator/packages.rs
@@ -19,13 +19,14 @@ impl PackageGenerator {
     }
 }
 
+#[allow(clippy::to_string_trait_impl)]
 impl ToString for PackageGenerator {
     fn to_string(&self) -> String {
         codegen::Scope::new()
             .raw("// NOTE: This file was automatically generated.")
             .raw("#![allow(unused_variables, dead_code, unused_imports)]")
-            .raw(&self.modules.join("\n"))
-            .raw(&self.usages.join("\n"))
+            .raw(self.modules.join("\n"))
+            .raw(self.usages.join("\n"))
             .push_trait(telemetry_data_trait())
             .to_string()
     }
@@ -37,7 +38,7 @@ fn telemetry_data_trait() -> codegen::Trait {
         .vis("pub")
         .doc("Common interface implemented by telemetry data contacts.")
         .new_fn("envelope_name")
-        .doc(&format!(
+        .doc(format!(
             "Returns the name used when this is embedded within an [{name}](trait.{name}.html) container.",
             name = "Envelope"
         ))
@@ -60,7 +61,7 @@ fn telemetry_data_trait() -> codegen::Trait {
 
     telemetry_data
         .new_fn("base_type")
-        .doc(&format!(
+        .doc(format!(
             "Returns the base type when placed within an [{name}](trait.{name}.html) container.",
             name = "Data"
         ))

--- a/appinsights-contracts-codegen/src/compiler/generator/schemas.rs
+++ b/appinsights-contracts-codegen/src/compiler/generator/schemas.rs
@@ -50,6 +50,7 @@ impl Visitor for SchemaGenerator {
     }
 }
 
+#[allow(clippy::to_string_trait_impl)]
 impl ToString for SchemaGenerator {
     fn to_string(&self) -> String {
         self.body.to_string()

--- a/appinsights-contracts-codegen/src/compiler/generator/structs.rs
+++ b/appinsights-contracts-codegen/src/compiler/generator/structs.rs
@@ -238,13 +238,13 @@ impl TelemetryDataTraitGenerator {
         implementation
             .impl_trait("TelemetryData")
             .new_fn("base_type")
-            .doc(&format!(
+            .doc(format!(
                 "Returns the base type when placed within an [{name}](trait.{name}.html) container.",
                 name = "Data"
             ))
             .arg_ref_self()
             .ret("String")
-            .line(&format!(r#"String::from("{}")"#, name));
+            .line(format!(r#"String::from("{}")"#, name));
 
         Self {
             implementation,

--- a/appinsights-contracts-codegen/src/compiler/generator/types.rs
+++ b/appinsights-contracts-codegen/src/compiler/generator/types.rs
@@ -76,7 +76,7 @@ impl From<ComplexType> for codegen::Type {
                     UserType::Struct(struct_) => struct_.name().to_string(),
                     UserType::Enum(enum_) => enum_.name().to_string(),
                 };
-                codegen::Type::new(&name)
+                codegen::Type::new(name)
             }
         }
     }

--- a/appinsights-contracts-codegen/src/compiler/mod.rs
+++ b/appinsights-contracts-codegen/src/compiler/mod.rs
@@ -14,7 +14,7 @@ use crate::parser::Parser;
 use crate::Result;
 
 pub fn compile_all(input_dir: PathBuf, output_dir: PathBuf) -> Result<()> {
-    let mut modules: Vec<_> = fs::read_dir(&input_dir)?
+    let mut modules: Vec<_> = fs::read_dir(input_dir)?
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
         .map(|path| Module::try_from((path, output_dir.clone())).expect("unable to read module path"))
         .collect();
@@ -39,13 +39,13 @@ fn compile_files<'a>(modules: impl Iterator<Item = &'a Module>) -> Result<()> {
 }
 
 fn compile(module: &Module) -> Result<()> {
-    let parser = Parser::default();
+    let parser = Parser;
     let schema = parser.parse(module.source_path())?;
 
     let mut generator = SchemaGenerator::new();
     generator.visit_schema(&schema);
 
-    fs::write(&module.path(), generator.to_string())?;
+    fs::write(module.path(), generator.to_string())?;
     Ok(())
 }
 

--- a/appinsights-contracts-codegen/src/parser.rs
+++ b/appinsights-contracts-codegen/src/parser.rs
@@ -9,7 +9,7 @@ pub struct Parser;
 
 impl Parser {
     pub fn parse(&self, path: &Path) -> Result<Schema> {
-        let schema = serde_json::from_reader(File::open(&path)?)?;
+        let schema = serde_json::from_reader(File::open(path)?)?;
         Ok(schema)
     }
 }

--- a/appinsights/Cargo.toml
+++ b/appinsights/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "0.8", features = ["v4"], default-features = false }
 reqwest = { version = "0.11", features = ["json"], default-features = false }
 log = "0.4"
 sm = "0.9"
-tokio = { version = "1", features = ["rt"], default-features = false }
+tokio = { version = "1", features = ["rt", "macros"], default-features = false }
 paste = "1.0"
 hostname = "0.3"
 futures-util = { version = "0.3", default-features = false }

--- a/appinsights/Cargo.toml
+++ b/appinsights/Cargo.toml
@@ -9,10 +9,7 @@ documentation = "https://docs.rs/appinsights"
 repository = "https://github.com/dmolokanov/appinsights-rs"
 readme = "../README.md"
 keywords = ["logging", "tracing", "metrics", "APM"]
-categories = [
-    "development-tools::debugging",
-    "development-tools::profiling"
-]
+categories = ["development-tools::debugging", "development-tools::profiling"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -49,9 +46,16 @@ env_logger = "0.9"
 lazy_static = "1.4"
 matches = "0.1"
 hyper = { version = "0.14", features = ["server"], default-features = false }
-tokio = { version = "1.21", features = ["macros", "rt-multi-thread"], default-features = false }
+tokio = { version = "1.21", features = [
+    "macros",
+    "rt-multi-thread",
+], default-features = false }
 parking_lot = "0.12"
 
 [[example]]
 name = "blocking"
+required-features = ["blocking"]
+
+[[test]]
+name = "telemetry_blocking"
 required-features = ["blocking"]

--- a/appinsights/Cargo.toml
+++ b/appinsights/Cargo.toml
@@ -27,14 +27,14 @@ blocking = []
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["clock"], default-features = false }
-http = "0.2"
-uuid = { version = "1.2", features = ["v4"], default-features = false }
-reqwest = { version = "0.11", features = ["json"], default-features = false }
+http = "1.1"
+uuid = { version = "1.10", features = ["v4"], default-features = false }
+reqwest = { version = "0.12", features = ["json"], default-features = false }
 log = "0.4"
 sm = "0.9"
 tokio = { version = "1", features = ["rt", "macros"], default-features = false }
 paste = "1.0"
-hostname = "0.3"
+hostname = "0.4"
 futures-util = { version = "0.3", default-features = false }
 futures-channel = "0.3"
 crossbeam-queue = "0.3"
@@ -45,11 +45,16 @@ test-case = "2.2"
 env_logger = "0.9"
 lazy_static = "1.4"
 matches = "0.1"
-hyper = { version = "0.14", features = ["server"], default-features = false }
+graceful-shutdown = "0.3"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["server"], default-features = false }
+hyper-util = { version = "0.1", features = ["service"]}
 tokio = { version = "1.21", features = [
     "macros",
     "rt-multi-thread",
+    "net",
 ], default-features = false }
+tower = { version = "0.5", features = ["util"] }
 parking_lot = "0.12"
 
 [[example]]

--- a/appinsights/Cargo.toml
+++ b/appinsights/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0"
 chrono = "0.4"
 http = "0.2"
-uuid = { version = "0.8", features = ["v4"], default-features = false }
+uuid = { version = "1.1", features = ["v4"], default-features = false }
 reqwest = { version = "0.11", features = ["json"], default-features = false }
 log = "0.4"
 sm = "0.9"

--- a/appinsights/src/blocking/integration_tests.rs
+++ b/appinsights/src/blocking/integration_tests.rs
@@ -1,4 +1,7 @@
 use std::{
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
         mpsc::{self, Receiver, RecvTimeoutError},
@@ -8,16 +11,18 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use http_body_util::Full;
 use hyper::{
-    body::Buf,
-    service::{make_service_fn, service_fn},
-    Body, Request, Response, Server, StatusCode,
+    body::{Bytes, Incoming},
+    service::Service,
+    Request, Response, StatusCode,
 };
+use hyper_util::rt::TokioIo;
 use lazy_static::lazy_static;
 use matches::assert_matches;
 use parking_lot::Mutex;
 use serde_json::json;
-use tokio::sync::oneshot;
+use tokio::{net::TcpListener, sync::oneshot};
 
 use crate::{blocking::TelemetryClient, timeout, TelemetryConfig};
 
@@ -396,6 +401,47 @@ impl Drop for HyperTestServer {
     }
 }
 
+#[derive(Debug, Clone)]
+struct TestServerService {
+    counter: Arc<AtomicUsize>,
+    requests_channel: std::sync::mpsc::Sender<String>,
+    responses: Arc<Vec<Response<String>>>,
+}
+
+impl Service<Request<Incoming>> for TestServerService {
+    type Response = Response<Full<Bytes>>;
+    type Error = hyper::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&self, request: Request<Incoming>) -> Self::Future {
+        let sender = self.requests_channel.clone();
+        let count = self.counter.fetch_add(1, Ordering::AcqRel);
+        let response = self.responses.get(count).cloned();
+
+        Box::pin(async move {
+            // Read the request body
+            // Then send into into the shared channel
+            use http_body_util::BodyExt;
+            let body = request.into_body().collect().await.expect("reading body");
+            let slice = body.to_bytes().to_vec();
+            let body = String::from_utf8_lossy(slice.as_slice()).to_string();
+            sender.send(body).expect("send body into requests channel");
+
+            let response = match response {
+                Some(response) => {
+                    let bytes = response.body().as_bytes();
+                    Response::builder()
+                        .status(response.status())
+                        .body(Full::new(Bytes::copy_from_slice(bytes)))
+                        .unwrap()
+                }
+                None => Response::builder().body(Full::new(Bytes::new())).unwrap(),
+            };
+            Ok(response)
+        })
+    }
+}
+
 impl Builder {
     fn response(mut self, status: StatusCode, body: impl ToString, retry_after: Option<DateTime<Utc>>) -> Self {
         let mut builder = Response::builder().status(status);
@@ -425,76 +471,68 @@ impl Builder {
     }
 
     fn create(self) -> HyperTestServer {
-        let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
-        let (url_sender, url_receiver) = mpsc::channel::<String>();
-        let (request_sender, request_receiver) = mpsc::channel::<String>();
+        let (shutdown_send, shutdown_recv) = oneshot::channel();
+        let (request_sender, request_receiver) = mpsc::channel();
 
         let responses = Arc::new(self.responses);
         let counter = Arc::new(AtomicUsize::new(0));
 
-        let make_service = make_service_fn(move |_| {
-            let request_sender = request_sender.clone();
-            let counter = counter.clone();
-            let responses = responses.clone();
+        let shutdown = graceful_shutdown::Shutdown::new();
+        let shutdown_task = shutdown.shutdown_after(shutdown_recv);
 
-            async move {
-                Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
-                    let request_sender = request_sender.clone();
-                    let counter = counter.clone();
-                    let responses = responses.clone();
+        let (addr, server) = {
+            let addr = SocketAddr::from(([0, 0, 0, 0], 0));
+            let std_listener = std::net::TcpListener::bind(addr).expect("bind to localhost");
+            std_listener
+                .set_nonblocking(true)
+                .expect("convert std::net::TcpListener to non-blocking");
+            let addr = std_listener.local_addr().expect("localhost local_addr");
 
-                    async move {
-                        let body = hyper::body::aggregate(req).await?;
-                        use std::io::Read;
+            let server = async move {
+                let listener = TcpListener::from_std(std_listener).expect("from std::net::TcpListener");
+                // Initialize the service that will be cloned between each served connection,
+                // effectively allowing us shared state access in our handler.
+                let service = TestServerService {
+                    counter: counter.clone(),
+                    requests_channel: request_sender.clone(),
+                    responses: responses.clone(),
+                };
 
-                        let mut content = String::default();
-                        body.reader().read_to_string(&mut content).unwrap();
-                        request_sender.send(content).unwrap();
+                loop {
+                    let stream = match shutdown.cancel_on_shutdown(listener.accept()).await {
+                        Some(Ok((conn, _))) => conn,
+                        Some(Err(_)) => break,
+                        None => break,
+                    };
+                    let io = TokioIo::new(stream);
+                    let service = service.clone();
 
-                        let count = counter.fetch_add(1, Ordering::AcqRel);
+                    tokio::spawn(async move {
+                        hyper::server::conn::http1::Builder::new()
+                            .serve_connection(io, service)
+                            .await
+                            .expect("serve local connection");
+                    });
+                }
+            };
 
-                        let response = if let Some(response) = responses.get(count) {
-                            Response::builder()
-                                .status(response.status())
-                                .body(Body::from(response.body().clone()))
-                                .unwrap()
-                        } else {
-                            Response::builder()
-                                .status(StatusCode::NOT_FOUND)
-                                .body(Body::empty())
-                                .unwrap()
-                        };
-
-                        Ok::<_, hyper::Error>(response)
-                    }
-                }))
-            }
-        });
+            (addr, server)
+        };
 
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().expect("runtime");
             rt.block_on(async move {
-                let server = Server::bind(&([0, 0, 0, 0], 0).into()).serve(make_service);
-
-                let url = format!("http://{}", server.local_addr());
-                url_sender.send(url).unwrap();
-
-                let graceful = server.with_graceful_shutdown(async {
-                    shutdown_receiver.await.ok();
-                });
-
-                if let Err(e) = graceful.await {
-                    log::error!("server error: {}", e);
-                }
-            });
+                tokio::spawn(shutdown_task);
+                server.await;
+            })
         });
 
-        let url = url_receiver.recv().expect("url");
+        let url = format!("http://{}", addr);
 
         HyperTestServer {
             url,
             request_recv: request_receiver,
-            shutdown: Some(shutdown_sender),
+            shutdown: Some(shutdown_send),
         }
     }
 }

--- a/appinsights/src/blocking/mod.rs
+++ b/appinsights/src/blocking/mod.rs
@@ -103,8 +103,8 @@ impl TelemetryClient {
     }
 
     /// Logs a HTTP request with the specified method, URL, duration and response code.
-    pub fn track_request(&self, method: Method, uri: Uri, duration: Duration, response_code: impl Into<String>) {
-        let event = RequestTelemetry::new(method, uri, duration, response_code);
+    pub fn track_request(&self, name: String, uri: Uri, duration: Duration, response_code: impl Into<String>) {
+        let event = RequestTelemetry::new(name, uri, duration, response_code);
         self.track(event)
     }
 

--- a/appinsights/src/blocking/mod.rs
+++ b/appinsights/src/blocking/mod.rs
@@ -24,7 +24,7 @@
 
 use std::{fmt::Display, time::Duration};
 
-use http::{Method, Uri};
+use http::Uri;
 use log::debug;
 use tokio::sync::mpsc;
 
@@ -51,7 +51,7 @@ impl TelemetryClient {
 
     /// Creates a new telemetry client configured with specified configuration.
     pub fn from_config(config: TelemetryConfig) -> Self {
-        Self::create(config, |config| InMemoryChannel::new(config))
+        Self::create(config, InMemoryChannel::new)
     }
 
     pub(crate) fn create<C, F>(config: TelemetryConfig, channel: F) -> Self
@@ -227,7 +227,7 @@ impl ChannelHandle {
                             ClientCommand::Stop => channel.close().await,
                             ClientCommand::Terminate => channel.terminate().await,
                         }
-                        let _ = req_tx.send(());
+                        let _ = req_tx.send(()).await;
                     }
                 };
                 rt.block_on(f);

--- a/appinsights/src/channel/memory.rs
+++ b/appinsights/src/channel/memory.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use crossbeam_queue::SegQueue;
 use futures_channel::mpsc::UnboundedSender;
-use log::{debug, trace, warn};
+use log::{debug, error, trace, warn};
 use tokio::task::JoinHandle;
 
 use crate::{
@@ -16,7 +16,12 @@ use crate::{
 /// A telemetry channel that stores events exclusively in memory.
 pub struct InMemoryChannel {
     items: Arc<SegQueue<Envelope>>,
-    command_sender: Option<UnboundedSender<Command>>,
+    // We have to keep the command sender wrapped in a type we can replace under the hood
+    // in case of Worker panicks.
+    command_sender: Option<Arc<Mutex<UnboundedSender<Command>>>>,
+    // If the worker ever ends up in a infinite panic loop, we need to detect in our restart code
+    // that a shutdown was requested, and that its unreasonable for us to continue restarting the worker
+    shutdown_sender: Option<tokio::sync::oneshot::Sender<()>>,
     join: Option<JoinHandle<()>>,
 }
 
@@ -26,26 +31,88 @@ impl InMemoryChannel {
         let items = Arc::new(SegQueue::new());
 
         let (command_sender, command_receiver) = futures_channel::mpsc::unbounded();
-        let worker = Worker::new(
-            Transmitter::new(config.endpoint()),
-            items.clone(),
-            command_receiver,
-            config.interval(),
-        );
+        let (shutdown_sender, mut shutdown_receiver) = tokio::sync::oneshot::channel();
 
-        let handle = tokio::spawn(worker.run());
+        let mutex_sender = Arc::new(Mutex::new(command_sender));
+
+        let worker_endpoint = config.endpoint().to_owned();
+        let worker_interval = config.interval();
+        let worker_items = items.clone();
+        let worker_sender = mutex_sender.clone();
+
+        // Create a task that will monitor the inner task that _actually_ run the worker.
+        let task = async move {
+            let mut receiver = command_receiver;
+
+            // We will loop-execute the inner task, to watch for panics.
+            loop {
+                let endpoint = worker_endpoint.clone();
+                let sender = worker_sender.clone();
+                let items = worker_items.clone();
+
+                let inner_task = async move {
+                    let worker = Worker::new(Transmitter::new(&endpoint), items, receiver, worker_interval);
+                    worker.run().await;
+                };
+
+                match tokio::spawn(inner_task).await {
+                    Err(e) => {
+                        match e.try_into_panic() {
+                            Ok(reason) => {
+                                let reason = reason.downcast_ref::<&str>().unwrap_or(&"no panic message provided");
+                                error!("InMemoryChannel worker panicked: {reason}");
+                            }
+                            Err(e) => warn!("InMemoryChannel worker shut down unexpectedly with error: {e}"),
+                        }
+
+                        if shutdown_receiver.try_recv().is_ok() {
+                            // A shutdown was requested after our panicking exit. Respect the shutdown
+                            // to avoid a potential inifite restart loop.
+                            let remaining_items = worker_items.clone().len();
+                            debug!("InMemoryChannel worker is not restarted due to shutdown already requested. There were {remaining_items} envelopes still in queue that will not be transmitted.");
+                            break;
+                        }
+                    }
+                    Ok(_) => {
+                        debug!("InMemoryChannel worker shut down gracefully");
+                        break;
+                    }
+                };
+
+                // re-initialize states so we can construct a new worker
+                let (command_sender, command_receiver) = futures_channel::mpsc::unbounded();
+                {
+                    // This replaces the "sender" side stored in InMemoryChannel
+                    let mut channel = sender.lock().unwrap_or_else(|e| {
+                        sender.clear_poison();
+                        e.into_inner()
+                    });
+                    let _ = std::mem::replace(&mut *channel, command_sender);
+                }
+                receiver = command_receiver;
+            }
+        };
+
+        let handle = tokio::spawn(task);
 
         Self {
             items,
-            command_sender: Some(command_sender),
+            command_sender: Some(mutex_sender),
+            shutdown_sender: Some(shutdown_sender),
             join: Some(handle),
         }
     }
 
     async fn shutdown(&mut self, command: Command) {
-        // send shutdown command
+        // send shutdown command to restart-worker-wrapper
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+        }
+
+        // send shutdown command to worker
         if let Some(sender) = self.command_sender.take() {
-            send_command(&sender, command);
+            let guard = sender.lock().unwrap();
+            send_command(&guard, command);
         }
 
         // wait until worker is finished
@@ -65,7 +132,8 @@ impl TelemetryChannel for InMemoryChannel {
 
     fn flush(&self) {
         if let Some(sender) = &self.command_sender {
-            send_command(sender, Command::Flush);
+            let guard = sender.lock().unwrap();
+            send_command(&guard, Command::Flush);
         }
     }
 

--- a/appinsights/src/channel/mod.rs
+++ b/appinsights/src/channel/mod.rs
@@ -14,7 +14,7 @@ use crate::contracts::Envelope;
 /// An implementation of [TelemetryChannel](trait.TelemetryChannel.html) is responsible for queueing
 /// and periodically submitting telemetry events.
 #[async_trait]
-pub trait TelemetryChannel {
+pub trait TelemetryChannel: Send {
     /// Queues a single telemetry item.
     fn send(&self, envelop: Envelope);
 

--- a/appinsights/src/channel/state.rs
+++ b/appinsights/src/channel/state.rs
@@ -3,7 +3,7 @@ use std::{mem, sync::Arc, time::Duration};
 use crossbeam_queue::SegQueue;
 use futures_channel::mpsc::UnboundedReceiver;
 use futures_util::{Future, Stream, StreamExt};
-use log::{debug, error, trace};
+use log::{debug, error, info, trace};
 use sm::{sm, Event};
 
 use crate::{
@@ -85,6 +85,7 @@ impl Worker {
         let mut items: Vec<Envelope> = Default::default();
         let mut retry = Retry::default();
 
+        info!("serving worker in infinite state-machine loop");
         loop {
             state = match state {
                 InitialReceiving(m) => self.handle_receiving(m, &mut items).await,

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -93,9 +93,11 @@ impl TelemetryClient {
     /// let mut client = TelemetryClient::new("<instrumentation key>".to_string());
     /// client.context_mut().tags_mut().insert("app_version".into(), "v0.1.1".to_string());
     /// client.context_mut().properties_mut().insert("Resource Group".into(), "my-rg".to_string());
+    /// *client.context_mut().timestamp_format() = SecondsFormat::Seconds;
     ///
     /// assert_eq!(client.context().tags().get("app_version"), Some(&"v0.1.1".to_string()));
     /// assert_eq!(client.context().properties().get("Resource Group"), Some(&"my-rg".to_string()));
+    /// assert_eq!(client.context().timestamp_format(), SecondsFormat::Seconds);
     /// ```
     pub fn context_mut(&mut self) -> &mut TelemetryContext {
         &mut self.context
@@ -140,7 +142,7 @@ impl TelemetryClient {
     /// # use appinsights::telemetry::SeverityLevel;
     /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
     /// client.track_metric("gateway_latency_ms", 113.0);
-    /// ```    
+    /// ```
     pub fn track_metric(&self, name: impl Into<String>, value: f64) {
         let event = MetricTelemetry::new(name, value);
         self.track(event)

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use http::{Method, Uri};
+use http::Uri;
 
 use crate::{
     channel::{InMemoryChannel, TelemetryChannel},
@@ -146,7 +146,7 @@ impl TelemetryClient {
         self.track(event)
     }
 
-    /// Logs a HTTP request with the specified method, URL, duration and response code.
+    /// Logs a HTTP request with the specified name, URL, duration and response code.
     ///
     /// # Examples
     ///
@@ -159,8 +159,8 @@ impl TelemetryClient {
     /// let uri: Uri = "https://api.github.com/dmolokanov/appinsights-rs".parse().unwrap();
     /// client.track_request(Method::GET, uri, Duration::from_millis(100), "200");
     /// ```
-    pub fn track_request(&self, method: Method, uri: Uri, duration: Duration, response_code: impl Into<String>) {
-        let event = RequestTelemetry::new(method, uri, duration, response_code);
+    pub fn track_request(&self, name: String, uri: Uri, duration: Duration, response_code: impl Into<String>) {
+        let event = RequestTelemetry::new(name, uri, duration, response_code);
         self.track(event)
     }
 

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -452,9 +452,6 @@ pub(crate) mod tests {
         }
     }
 
-    #[derive(Clone)]
-    pub(crate) struct TestData;
-
     impl From<(TelemetryContext, TestTelemetry)> for Envelope {
         fn from((_, _): (TelemetryContext, TestTelemetry)) -> Self {
             Envelope::default()

--- a/appinsights/src/client/mod.rs
+++ b/appinsights/src/client/mod.rs
@@ -7,8 +7,8 @@ use crate::{
     context::TelemetryContext,
     contracts::Envelope,
     telemetry::{
-        AvailabilityTelemetry, EventTelemetry, MetricTelemetry, RemoteDependencyTelemetry, RequestTelemetry,
-        SeverityLevel, Telemetry, TraceTelemetry,
+        AvailabilityTelemetry, EventTelemetry, ExceptionTelemetry, MetricTelemetry, RemoteDependencyTelemetry,
+        RequestTelemetry, SeverityLevel, Telemetry, TraceTelemetry,
     },
     TelemetryConfig,
 };
@@ -207,6 +207,37 @@ impl TelemetryClient {
     pub fn track_availability(&self, name: impl Into<String>, duration: Duration, success: bool) {
         let event = AvailabilityTelemetry::new(name, duration, success);
         self.track(event)
+    }
+
+    /// Logs an exception with the specified message, exception type name,
+    /// severity level, and problem ID.
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # use appinsights::TelemetryClient;
+    /// # let client = TelemetryClient::new("<instrumentation key>".to_string());
+    /// use std::time::Duration;
+    ///
+    /// client.track_exception(
+    ///     "This is a message",
+    ///     "Panic",
+    ///     Some(std::backtrace::Backtrace::force_capture().to_string())
+    ///     "Panic@some_function"
+    /// );
+    /// ```
+    pub fn track_exception(
+        &self,
+        message: impl Into<String>,
+        exception_type_name: impl Into<String>,
+        stack_trace: Option<impl Into<String>>,
+        problem_id: Option<impl Into<String>>,
+    ) {
+        let exception = ExceptionTelemetry::new(Some(SeverityLevel::Error), problem_id).with_message(
+            message,
+            exception_type_name,
+            stack_trace,
+        );
+        self.track(exception)
     }
 
     /// Submits a specific telemetry event.

--- a/appinsights/src/config.rs
+++ b/appinsights/src/config.rs
@@ -40,7 +40,7 @@ impl TelemetryConfig {
 
     /// Creates a new telemetry configuration builder with default parameters.
     pub fn builder() -> DefaultTelemetryConfigBuilder {
-        DefaultTelemetryConfigBuilder::default()
+        DefaultTelemetryConfigBuilder
     }
 
     /// Returns an instrumentation key for the client.

--- a/appinsights/src/config.rs
+++ b/appinsights/src/config.rs
@@ -1,6 +1,8 @@
 //! Module for telemetry client configuration.
 use std::time::Duration;
 
+use chrono::SecondsFormat;
+
 /// Configuration data used to initialize a new [`TelemetryClient`](../struct.TelemetryClient.html) with.
 ///
 /// # Examples
@@ -30,6 +32,9 @@ pub struct TelemetryConfig {
 
     /// Maximum time to wait until send a batch of telemetry.
     interval: Duration,
+
+    /// Timestamp format for telemetry data.
+    timestamp_format: SecondsFormat,
 }
 
 impl TelemetryConfig {
@@ -57,6 +62,11 @@ impl TelemetryConfig {
     pub fn interval(&self) -> Duration {
         self.interval
     }
+
+    /// Returns timestamp format for telemetry data.
+    pub fn timestamp_format(&self) -> SecondsFormat {
+        self.timestamp_format
+    }
 }
 
 /// Constructs a new instance of a [`TelemetryConfig`](struct.TelemetryConfig.html) with required
@@ -74,6 +84,7 @@ impl DefaultTelemetryConfigBuilder {
             i_key: i_key.into(),
             endpoint: "https://dc.services.visualstudio.com/v2/track".into(),
             interval: Duration::from_secs(2),
+            timestamp_format: SecondsFormat::Millis,
         }
     }
 }
@@ -83,6 +94,7 @@ pub struct TelemetryConfigBuilder {
     i_key: String,
     endpoint: String,
     interval: Duration,
+    timestamp_format: SecondsFormat,
 }
 
 impl TelemetryConfigBuilder {
@@ -110,12 +122,19 @@ impl TelemetryConfigBuilder {
         self
     }
 
+    /// Initializes a builder with a format for the event timestamp in telemetry data.
+    pub fn timestamp_format(mut self, format: SecondsFormat) -> Self {
+        self.timestamp_format = format;
+        self
+    }
+
     /// Constructs a new instance of a [`TelemetryConfig`](struct.TelemetryConfig.html) with custom settings.
     pub fn build(self) -> TelemetryConfig {
         TelemetryConfig {
             i_key: self.i_key,
             endpoint: self.endpoint,
             interval: self.interval,
+            timestamp_format: self.timestamp_format,
         }
     }
 }
@@ -132,7 +151,8 @@ mod tests {
             TelemetryConfig {
                 i_key: "instrumentation key".into(),
                 endpoint: "https://dc.services.visualstudio.com/v2/track".into(),
-                interval: Duration::from_secs(2)
+                interval: Duration::from_secs(2),
+                timestamp_format: SecondsFormat::Millis,
             },
             config
         )
@@ -144,13 +164,15 @@ mod tests {
             .i_key("instrumentation key")
             .endpoint("https://google.com")
             .interval(Duration::from_micros(100))
+            .timestamp_format(SecondsFormat::Secs)
             .build();
 
         assert_eq!(
             TelemetryConfig {
                 i_key: "instrumentation key".into(),
                 endpoint: "https://google.com".into(),
-                interval: Duration::from_micros(100)
+                interval: Duration::from_micros(100),
+                timestamp_format: SecondsFormat::Secs,
             },
             config
         );

--- a/appinsights/src/contracts/data.rs
+++ b/appinsights/src/contracts/data.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 // NOTE: This file was automatically generated.
 
 /// Data struct to contain both B and C sections.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "baseType", content = "baseData")]
 pub enum Data {

--- a/appinsights/src/contracts/exception_data.rs
+++ b/appinsights/src/contracts/exception_data.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionData {
     pub ver: i32,
-    pub exceptions: ExceptionDetails,
+    pub exceptions: Vec<ExceptionDetails>,
     pub severity_level: Option<SeverityLevel>,
     pub problem_id: Option<String>,
     pub properties: Option<std::collections::BTreeMap<String, String>>,
@@ -19,7 +19,7 @@ impl Default for ExceptionData {
     fn default() -> Self {
         Self {
             ver: 2,
-            exceptions: ExceptionDetails::default(),
+            exceptions: Vec::default(),
             severity_level: Option::default(),
             problem_id: Option::default(),
             properties: Option::default(),

--- a/appinsights/src/contracts/exception_details.rs
+++ b/appinsights/src/contracts/exception_details.rs
@@ -7,13 +7,13 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExceptionDetails {
-    id: Option<i32>,
-    outer_id: Option<i32>,
-    type_name: String,
-    message: String,
-    has_full_stack: Option<bool>,
-    stack: Option<String>,
-    parsed_stack: Option<StackFrame>,
+    pub id: Option<i32>,
+    pub outer_id: Option<i32>,
+    pub type_name: String,
+    pub message: String,
+    pub has_full_stack: Option<bool>,
+    pub stack: Option<String>,
+    pub parsed_stack: Vec<StackFrame>,
 }
 
 impl Default for ExceptionDetails {
@@ -25,7 +25,7 @@ impl Default for ExceptionDetails {
             message: String::default(),
             has_full_stack: Some(true),
             stack: Option::default(),
-            parsed_stack: Option::default(),
+            parsed_stack: Vec::default(),
         }
     }
 }

--- a/appinsights/src/contracts/response.rs
+++ b/appinsights/src/contracts/response.rs
@@ -13,5 +13,6 @@ pub struct Transmission {
 pub struct TransmissionItem {
     pub index: usize,
     pub status_code: u16,
+    #[expect(dead_code)]
     pub message: String,
 }

--- a/appinsights/src/contracts/stack_frame.rs
+++ b/appinsights/src/contracts/stack_frame.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 // NOTE: This file was automatically generated.
 
 /// Stack frame information.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackFrame {
     level: i32,
@@ -12,16 +12,4 @@ pub struct StackFrame {
     assembly: Option<String>,
     file_name: Option<String>,
     line: Option<i32>,
-}
-
-impl Default for StackFrame {
-    fn default() -> Self {
-        Self {
-            level: i32::default(),
-            method: String::default(),
-            assembly: Option::default(),
-            file_name: Option::default(),
-            line: Option::default(),
-        }
-    }
 }

--- a/appinsights/src/contracts/stack_frame.rs
+++ b/appinsights/src/contracts/stack_frame.rs
@@ -7,9 +7,9 @@ use serde::Serialize;
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StackFrame {
-    level: i32,
-    method: String,
-    assembly: Option<String>,
-    file_name: Option<String>,
-    line: Option<i32>,
+    pub level: i32,
+    pub method: String,
+    pub assembly: Option<String>,
+    pub file_name: Option<String>,
+    pub line: Option<i32>,
 }

--- a/appinsights/src/lib.rs
+++ b/appinsights/src/lib.rs
@@ -51,6 +51,7 @@
 //! [`TelemetryClient`](struct.TelemetryClient.html) with it.
 //!
 //! ```rust
+//! use chrono::SecondsFormat;
 //! use std::time::Duration;
 //! use appinsights::{TelemetryClient, TelemetryConfig};
 //! use appinsights::telemetry::SeverityLevel;
@@ -61,10 +62,12 @@
 //!     .i_key("<instrumentation key>")
 //!     // set a new maximum time to wait until data will be sent to the server
 //!     .interval(Duration::from_secs(5))
+//!     // set the format of event timestamps
+//!     .timestamp_format(SecondsFormat::Micros)
 //!     // construct a new instance of telemetry configuration
 //!     .build();
 //!
-//! // configure telemetry client with default settings
+//! // configure telemetry client with the custom settings
 //! let client = TelemetryClient::from_config(config);
 //!
 //! // send trace telemetry to the Application Insights server

--- a/appinsights/src/lib.rs
+++ b/appinsights/src/lib.rs
@@ -29,8 +29,8 @@
 //! ## Examples
 //!
 //! 1. Create an new instance of [`TelemetryClient`](struct.TelemetryClient.html) with an
-//! Instrumentation Key and default settings. To get more control over client behavior please visit
-//! [`TelemetryConfig`](struct.TelemetryConfig.html).
+//!    Instrumentation Key and default settings. To get more control over client behavior please visit
+//!    [`TelemetryConfig`](struct.TelemetryConfig.html).
 //! 2. Send an event telemetry to the Application Insights service.
 //!
 //! ```rust
@@ -160,13 +160,13 @@
 //! worker stores it in memory, so when application crashes the data will be lost. Luckily SDK
 //! provides several convenient methods to deal with this issue.
 //! * [`flush_channel`](struct.TelemetryClient.html#method.flush_channel) will trigger telemetry submission
-//! as soon as possible. It returns immediately and telemetry is no guaranteed to be sent.
+//!   as soon as possible. It returns immediately and telemetry is no guaranteed to be sent.
 //! * [`close_channel`](struct.TelemetryClient.html#method.close_channel) will cause the channel to
-//! stop accepting any new telemetry items, submit all pending ones, block current task and
-//! wait until data will be sent at most once. If telemetry submission fails, it will not retry.
-//! This method consumes the value of client so it makes impossible to use a client with close channel.
+//!   stop accepting any new telemetry items, submit all pending ones, block current task and
+//!   wait until data will be sent at most once. If telemetry submission fails, it will not retry.
+//!   This method consumes the value of client so it makes impossible to use a client with close channel.
 //! * [`terminate`](struct.TelemetryClient.html#method.terminate) will trigger termination of submission flow, all pending items discarded and
-//! current task will be blocked until all resources freed.
+//!   current task will be blocked until all resources freed.
 #![deny(unused_extern_crates)]
 #![deny(missing_docs)]
 

--- a/appinsights/src/telemetry/availability.rs
+++ b/appinsights/src/telemetry/availability.rs
@@ -1,6 +1,6 @@
 use std::time::Duration as StdDuration;
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -127,7 +127,7 @@ impl From<(TelemetryContext, AvailabilityTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, AvailabilityTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Availability".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::AvailabilityData(AvailabilityData {
@@ -153,7 +153,7 @@ impl From<(TelemetryContext, AvailabilityTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
 
@@ -161,8 +161,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -206,8 +210,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/availability.rs
+++ b/appinsights/src/telemetry/availability.rs
@@ -133,7 +133,7 @@ impl From<(TelemetryContext, AvailabilityTelemetry)> for Envelope {
             data: Some(Base::Data(Data::AvailabilityData(AvailabilityData {
                 id: telemetry
                     .id
-                    .map(|id| id.to_hyphenated().to_string())
+                    .map(|id| id.as_hyphenated().to_string())
                     .unwrap_or_default(),
                 name: telemetry.name,
                 duration: telemetry.duration.to_string(),

--- a/appinsights/src/telemetry/event.rs
+++ b/appinsights/src/telemetry/event.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -98,7 +98,7 @@ impl From<(TelemetryContext, EventTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, EventTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Event".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::EventData(EventData {
@@ -116,7 +116,7 @@ impl From<(TelemetryContext, EventTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
     use crate::time;
@@ -125,8 +125,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 600));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -166,8 +170,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/exception.rs
+++ b/appinsights/src/telemetry/exception.rs
@@ -107,6 +107,11 @@ impl ExceptionTelemetry {
         self
     }
 
+    /// Returns mutable reference to the timestamp.
+    pub fn timestamp_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
     /// Create a new [ExceptionTelemetryBuilder], used to construct an [ExceptionTelemetry].
     pub fn builder() -> ExceptionTelemetryBuilder {
         ExceptionTelemetryBuilder::default()

--- a/appinsights/src/telemetry/exception.rs
+++ b/appinsights/src/telemetry/exception.rs
@@ -1,1 +1,222 @@
 // TODO implement exception collection telemetry item
+
+use chrono::{DateTime, SecondsFormat, Utc};
+
+use crate::{
+    contracts::{Base, Data, Envelope, ExceptionData, ExceptionDetails},
+    telemetry::{ContextTags, Measurements, Properties, SeverityLevel, Telemetry},
+    time, TelemetryContext,
+};
+
+/// Represents errors that occur during application execution.
+///
+/// # Examples
+/// ```rust, no_run
+/// # use appinsights::TelemetryClient;
+/// # let client = TelemetryClient::new("<instrumentation key>".to_string());
+/// use appinsights::telemetry::{Telemetry, ExceptionTelemetry};
+///
+/// // create a telemetry item
+/// let mut telemetry = ExceptionTelemetry::new(
+///     "File does not exist",
+///     Some(SeverityLevel::Error),
+///     Some(format!{"FileNotFound: {}:{}:{}", file!(), line!(), column!()})
+/// )
+/// .with_message("File does not exist", "FileNotFound", None);
+///
+/// // attach custom properties, measurements and context tags
+/// telemetry.properties_mut().insert("component".to_string(), "data_processor".to_string());
+/// telemetry.tags_mut().insert("os_version".to_string(), "linux x86_64".to_string());
+/// telemetry.measurements_mut().insert("body_size".to_string(), 115.0);
+///
+/// // submit telemetry item to server
+/// client.track(telemetry);
+/// ```
+#[derive(Debug)]
+pub struct ExceptionTelemetry {
+    /// Exception chain - list of inner exceptions.
+    /// TODO: should this be a Vec? Currently only one exception, not exceptions.
+    exceptions: Vec<ExceptionDetails>,
+
+    /// Severity level. Mostly used to indicate exception severity level
+    /// when it is reported by logging library.
+    severity_level: Option<SeverityLevel>,
+
+    /// Identifier of where the exception was thrown in code.
+    /// Used for exceptions grouping. Typically a combination of exception type
+    /// and a function from the call stack.
+    problem_id: Option<String>,
+
+    /// Collection of custom properties.
+    properties: Properties,
+
+    /// Collection of custom measurements.
+    measurements: Measurements,
+
+    /// The time stamp when this telemetry was measured.
+    timestamp: DateTime<Utc>,
+
+    /// Telemetry context containing extra, optional tags.
+    tags: ContextTags,
+}
+
+impl ExceptionTelemetry {
+    /// Create an empty exception telemetry item.
+    pub fn new(severity_level: Option<SeverityLevel>, problem_id: Option<impl Into<String>>) -> Self {
+        Self {
+            exceptions: vec![],
+            severity_level,
+            problem_id: problem_id.map(|id| id.into()),
+            timestamp: time::now(),
+            properties: Properties::default(),
+            measurements: Measurements::default(),
+            tags: ContextTags::default(),
+        }
+    }
+
+    /// Add a new exception with the given parameters to the list of exceptions
+    /// of this exception telemetry item.
+    ///
+    /// ### Bugs
+    /// Adding multiple exceptions to a single telemetry item does not
+    /// actually work yet. The nesting is not shown in Azure App Insights,
+    /// and messages of the exceptions are just concatenated.
+    pub fn with_message(
+        mut self,
+        message: impl Into<String>,
+        type_name: impl Into<String>,
+        stack_trace: Option<impl Into<String>>,
+    ) -> Self {
+        self.exceptions.push(ExceptionDetails {
+            message: message.into(),
+            type_name: type_name.into(),
+            stack: stack_trace.map(|s| s.into()),
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Add an exception to the list of exceptions of this exception
+    /// telemetry item.
+    ///
+    /// ### Bugs
+    /// Adding multiple exceptions to a single telemetry item does not
+    /// actually work yet.
+    pub fn with_exception(mut self, exception: ExceptionDetails) -> Self {
+        self.exceptions.push(exception);
+        self
+    }
+
+    /// Create a new [ExceptionTelemetryBuilder], used to construct an [ExceptionTelemetry].
+    pub fn builder() -> ExceptionTelemetryBuilder {
+        ExceptionTelemetryBuilder::default()
+    }
+}
+
+impl Telemetry for ExceptionTelemetry {
+    fn properties(&self) -> &Properties {
+        &self.properties
+    }
+
+    fn properties_mut(&mut self) -> &mut Properties {
+        &mut self.properties
+    }
+
+    fn tags(&self) -> &ContextTags {
+        &self.tags
+    }
+
+    fn tags_mut(&mut self) -> &mut ContextTags {
+        &mut self.tags
+    }
+
+    fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+}
+
+impl From<(TelemetryContext, ExceptionTelemetry)> for Envelope {
+    fn from((context, telemetry): (TelemetryContext, ExceptionTelemetry)) -> Self {
+        Self {
+            name: "Microsoft.ApplicationInsights.Exception".into(),
+            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            i_key: Some(context.i_key),
+            tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
+            data: Some(Base::Data(Data::ExceptionData(ExceptionData {
+                exceptions: telemetry.exceptions,
+                problem_id: telemetry.problem_id,
+                severity_level: telemetry.severity_level.map(|s| s.into()),
+                properties: Some(Properties::combine(context.properties, telemetry.properties).into()),
+                measurements: Some(telemetry.measurements.into()),
+                ..Default::default()
+            }))),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ExceptionTelemetryBuilder {
+    exceptions: Vec<ExceptionDetails>,
+    severity_level: Option<SeverityLevel>,
+    problem_id: Option<String>,
+    properties: Option<Properties>,
+    measurements: Option<Measurements>,
+    timestamp: Option<DateTime<Utc>>,
+    tags: Option<ContextTags>,
+}
+
+impl ExceptionTelemetryBuilder {
+    pub fn with_severity(mut self, severity: SeverityLevel) -> Self {
+        self.severity_level = Some(severity);
+        self
+    }
+
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Properties) -> Self {
+        self.properties = Some(properties);
+        self
+    }
+
+    pub fn with_tags(mut self, tags: ContextTags) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
+    pub fn with_measurements(mut self, measurements: Measurements) -> Self {
+        self.measurements = Some(measurements);
+        self
+    }
+
+    pub fn with_problem_id(mut self, problem_id: impl Into<String>) -> Self {
+        self.problem_id = Some(problem_id.into());
+        self
+    }
+
+    /// Can be called multiple times to add several exceptions to the exception
+    /// chain of the `ExceptionTelemetry`.
+    ///
+    /// ### Bugs
+    /// Adding multiple exceptions to a single telemetry item does not
+    /// actually work yet.
+    pub fn with_exception(mut self, exception: ExceptionDetails) -> Self {
+        self.exceptions.push(exception);
+        self
+    }
+
+    pub fn build(self) -> ExceptionTelemetry {
+        ExceptionTelemetry {
+            severity_level: self.severity_level,
+            exceptions: self.exceptions,
+            timestamp: self.timestamp.unwrap_or_else(time::now),
+            properties: self.properties.unwrap_or_default(),
+            tags: self.tags.unwrap_or_default(),
+            measurements: self.measurements.unwrap_or_default(),
+            problem_id: self.problem_id,
+        }
+    }
+}

--- a/appinsights/src/telemetry/exception.rs
+++ b/appinsights/src/telemetry/exception.rs
@@ -1,6 +1,6 @@
 // TODO implement exception collection telemetry item
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     contracts::{Base, Data, Envelope, ExceptionData, ExceptionDetails},
@@ -144,7 +144,7 @@ impl From<(TelemetryContext, ExceptionTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, ExceptionTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Exception".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::ExceptionData(ExceptionData {

--- a/appinsights/src/telemetry/metric/aggregation.rs
+++ b/appinsights/src/telemetry/metric/aggregation.rs
@@ -229,7 +229,7 @@ mod tests {
         let mut telemetry = AggregateMetricTelemetry::new("stats");
         *telemetry.stats_mut() = stats;
 
-        assert!((telemetry.stats().value - 15.0).abs() < std::f64::EPSILON);
+        assert!((telemetry.stats().value - 15.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/appinsights/src/telemetry/metric/aggregation.rs
+++ b/appinsights/src/telemetry/metric/aggregation.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -100,7 +100,7 @@ impl From<(TelemetryContext, AggregateMetricTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, AggregateMetricTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Metric".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::MetricData(MetricData {
@@ -126,7 +126,7 @@ impl From<(TelemetryContext, AggregateMetricTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
     use crate::time;
@@ -135,8 +135,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 100));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -180,8 +184,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 101));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/metric/measurement.rs
+++ b/appinsights/src/telemetry/metric/measurement.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -87,7 +87,7 @@ impl From<(TelemetryContext, MetricTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, MetricTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Metric".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::MetricData(MetricData {
@@ -110,7 +110,7 @@ impl From<(TelemetryContext, MetricTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
     use crate::time;
@@ -119,8 +119,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 100));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -160,8 +164,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 101));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/metric/stats.rs
+++ b/appinsights/src/telemetry/metric/stats.rs
@@ -65,8 +65,8 @@ impl Stats {
                 mean = self.value / self.count as f64;
             }
 
-            self.min = values.iter().fold(std::f64::NAN, |x, min| min.min(x));
-            self.max = values.iter().fold(std::f64::NAN, |x, max| max.max(x));
+            self.min = values.iter().fold(f64::NAN, |x, min| min.min(x));
+            self.max = values.iter().fold(f64::NAN, |x, max| max.max(x));
 
             // Welford's algorithm to compute variance. The divide occurs in the caller.
             let mut value = self.value;

--- a/appinsights/src/telemetry/mod.rs
+++ b/appinsights/src/telemetry/mod.rs
@@ -8,22 +8,25 @@ mod page_view;
 mod properties;
 mod remote_dependency;
 mod request;
+mod severity_level;
 mod tags;
 mod trace;
 
 pub use availability::AvailabilityTelemetry;
 pub use event::EventTelemetry;
+pub use exception::ExceptionTelemetry;
 pub use measurements::Measurements;
 pub use metric::{AggregateMetricTelemetry, MetricTelemetry, Stats};
 pub use page_view::PageViewTelemetry;
 pub use properties::Properties;
 pub use remote_dependency::RemoteDependencyTelemetry;
 pub use request::RequestTelemetry;
+pub use severity_level::SeverityLevel;
 pub use tags::{
     ApplicationTags, CloudTags, ContextTags, DeviceTags, InternalTags, LocationTags, OperationTags, SessionTags,
     UserTags,
 };
-pub use trace::{SeverityLevel, TraceTelemetry};
+pub use trace::TraceTelemetry;
 
 use chrono::{DateTime, Utc};
 

--- a/appinsights/src/telemetry/page_view.rs
+++ b/appinsights/src/telemetry/page_view.rs
@@ -128,7 +128,7 @@ impl From<(TelemetryContext, PageViewTelemetry)> for Envelope {
                 referrer_uri: None,
                 id: telemetry
                     .id
-                    .map(|id| id.to_hyphenated().to_string())
+                    .map(|id| id.as_hyphenated().to_string())
                     .unwrap_or_default(),
                 properties: Some(Properties::combine(context.properties, telemetry.properties).into()),
                 measurements: Some(telemetry.measurements.into()),

--- a/appinsights/src/telemetry/page_view.rs
+++ b/appinsights/src/telemetry/page_view.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 use http::Uri;
 
 use crate::{
@@ -118,7 +118,7 @@ impl From<(TelemetryContext, PageViewTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, PageViewTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.PageView".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::PageViewData(PageViewData {
@@ -143,7 +143,7 @@ impl From<(TelemetryContext, PageViewTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
 
@@ -151,8 +151,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -193,8 +197,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -1,6 +1,6 @@
 use std::time::Duration as StdDuration;
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -204,7 +204,7 @@ impl From<(TelemetryContext, RemoteDependencyTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, RemoteDependencyTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.RemoteDependency".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::RemoteDependencyData(RemoteDependencyData {
@@ -229,7 +229,7 @@ impl From<(TelemetryContext, RemoteDependencyTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
 
     use super::*;
 
@@ -237,7 +237,12 @@ mod tests {
     fn it_uses_specified_id() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let context = TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         let mut telemetry = RemoteDependencyTelemetry::new(
             "GET https://example.com/main.html",
             "HTTP",
@@ -275,8 +280,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -326,8 +335,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -146,6 +146,16 @@ impl RemoteDependencyTelemetry {
     pub fn set_id(&mut self, id: impl Into<String>) {
         self.id = Some(id.into());
     }
+
+    /// Set the `data` field of the dependency trace.
+    pub fn set_data(&mut self, data: impl Into<String>) {
+        self.data = Some(data.into());
+    }
+
+    /// Set the `tags` fields of the telemetry, replacing the existing one.
+    pub fn set_tags(&mut self, tags: ContextTags) {
+        self.tags = tags;
+    }
 }
 
 impl Telemetry for RemoteDependencyTelemetry {

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -120,6 +120,16 @@ impl RemoteDependencyTelemetry {
         &mut self.timestamp
     }
 
+    /// Returns the result code of the dependency call.
+    pub fn result_code(&self) -> &Option<String> {
+        &self.result_code
+    }
+
+    /// Returns mutable reference to the result code.
+    pub fn result_code_mut(&mut self) -> &mut Option<String> {
+        &mut self.result_code
+    }
+
     /// Sets the dependency id. Use this to link other telemetry to this dependency by setting their operation
     /// parent id to this id.
     ///

--- a/appinsights/src/telemetry/remote_dependency.rs
+++ b/appinsights/src/telemetry/remote_dependency.rs
@@ -115,6 +115,11 @@ impl RemoteDependencyTelemetry {
         &mut self.measurements
     }
 
+    /// Returns mutable reference to the timestamp.
+    pub fn timestamp_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
     /// Sets the dependency id. Use this to link other telemetry to this dependency by setting their operation
     /// parent id to this id.
     ///

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -115,6 +115,11 @@ impl RequestTelemetry {
         &mut self.measurements
     }
 
+    /// Returns mutable reference to the timestamp.
+    pub fn timestamp_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.timestamp
+    }
+
     /// Returns an indication of successful or unsuccessful call.
     pub fn is_success(&self) -> bool {
         if let Ok(response_code) = StatusCode::from_str(&self.response_code) {

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, time::Duration as StdDuration};
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 use http::{StatusCode, Uri};
 
 use crate::{
@@ -201,7 +201,7 @@ impl From<(TelemetryContext, RequestTelemetry)> for Envelope {
         let success = telemetry.is_success();
         Self {
             name: "Microsoft.ApplicationInsights.Request".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::RequestData(RequestData {
@@ -225,7 +225,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use chrono::TimeZone;
+    use chrono::{SecondsFormat, TimeZone};
     use http::Method;
 
     use super::*;
@@ -237,7 +237,12 @@ mod tests {
         uuid::set(Uuid::from_str("910b414a-f368-4b3a-aff6-326632aac566").unwrap());
 
         let id = "specified-id".to_string();
-        let context = TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         let method = Method::GET;
         let uri: Uri = "https://example.com/main.html".parse().unwrap();
         let name = format!("{method} {}", uri.path());
@@ -277,8 +282,12 @@ mod tests {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
         uuid::set(Uuid::from_str("910b414a-f368-4b3a-aff6-326632aac566").unwrap());
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -331,8 +340,12 @@ mod tests {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
         uuid::set(Uuid::from_str("910b414a-f368-4b3a-aff6-326632aac566").unwrap());
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/request.rs
+++ b/appinsights/src/telemetry/request.rs
@@ -195,7 +195,7 @@ impl From<(TelemetryContext, RequestTelemetry)> for Envelope {
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::RequestData(RequestData {
-                id: telemetry.id.unwrap_or_else(|| uuid::new().to_hyphenated().to_string()),
+                id: telemetry.id.unwrap_or_else(|| uuid::new().as_hyphenated().to_string()),
                 name: Some(telemetry.name),
                 duration: telemetry.duration.to_string(),
                 response_code: telemetry.response_code,

--- a/appinsights/src/telemetry/severity_level.rs
+++ b/appinsights/src/telemetry/severity_level.rs
@@ -1,0 +1,32 @@
+use crate::contracts::SeverityLevel as ContractsSeverityLevel;
+
+/// Defines the level of severity for the event.
+#[derive(Debug)]
+pub enum SeverityLevel {
+    /// Verbose severity level.
+    Verbose,
+
+    /// Information severity level.
+    Information,
+
+    /// Warning severity level.
+    Warning,
+
+    /// Error severity level.
+    Error,
+
+    /// Critical severity level.
+    Critical,
+}
+
+impl From<SeverityLevel> for ContractsSeverityLevel {
+    fn from(severity: SeverityLevel) -> Self {
+        match severity {
+            SeverityLevel::Verbose => ContractsSeverityLevel::Verbose,
+            SeverityLevel::Information => ContractsSeverityLevel::Information,
+            SeverityLevel::Warning => ContractsSeverityLevel::Warning,
+            SeverityLevel::Error => ContractsSeverityLevel::Error,
+            SeverityLevel::Critical => ContractsSeverityLevel::Critical,
+        }
+    }
+}

--- a/appinsights/src/telemetry/severity_level.rs
+++ b/appinsights/src/telemetry/severity_level.rs
@@ -1,7 +1,7 @@
 use crate::contracts::SeverityLevel as ContractsSeverityLevel;
 
 /// Defines the level of severity for the event.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum SeverityLevel {
     /// Verbose severity level.
     Verbose,

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Utc};
 
 use crate::{
     context::TelemetryContext,
@@ -174,7 +174,7 @@ impl From<(TelemetryContext, TraceTelemetry)> for Envelope {
     fn from((context, telemetry): (TelemetryContext, TraceTelemetry)) -> Self {
         Self {
             name: "Microsoft.ApplicationInsights.Message".into(),
-            time: telemetry.timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
+            time: telemetry.timestamp.to_rfc3339_opts(context.timestamp_format, true),
             i_key: Some(context.i_key),
             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
             data: Some(Base::Data(Data::MessageData(MessageData {
@@ -193,7 +193,7 @@ impl From<(TelemetryContext, TraceTelemetry)> for Envelope {
 mod tests {
     use std::collections::BTreeMap;
 
-    use chrono::{TimeZone, Utc};
+    use chrono::{SecondsFormat, TimeZone, Utc};
 
     use super::{SeverityLevel, TraceTelemetry};
     use crate::{
@@ -206,8 +206,12 @@ mod tests {
     fn it_overrides_properties_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 800));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.properties_mut().insert("test".into(), "ok".into());
         context.properties_mut().insert("no-write".into(), "fail".into());
 
@@ -248,8 +252,12 @@ mod tests {
     fn it_overrides_tags_from_context() {
         time::set(Utc.ymd(2019, 1, 2).and_hms_milli(3, 4, 5, 700));
 
-        let mut context =
-            TelemetryContext::new("instrumentation".into(), ContextTags::default(), Properties::default());
+        let mut context = TelemetryContext::new(
+            "instrumentation".into(),
+            SecondsFormat::Millis,
+            ContextTags::default(),
+            Properties::default(),
+        );
         context.tags_mut().insert("test".into(), "ok".into());
         context.tags_mut().insert("no-write".into(), "fail".into());
 

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -70,6 +70,16 @@ impl TraceTelemetry {
     pub fn measurements_mut(&mut self) -> &mut Measurements {
         &mut self.measurements
     }
+
+    /// Sets a new message of this trace telemetry.
+    pub fn set_message(&mut self, message: impl Into<String>) {
+        self.message = message.into();
+    }
+
+    /// Sets a new severity level of this trace telemetry.
+    pub fn set_severity(&mut self, severity: SeverityLevel) {
+        self.severity = severity;
+    }
 }
 
 impl Telemetry for TraceTelemetry {

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -48,6 +48,62 @@ pub struct TraceTelemetry {
     measurements: Measurements,
 }
 
+// This struct is a Option'fied version of TraceTelemetry
+#[derive(Debug, Default)]
+pub struct TraceTelemetryBuilder {
+    message: Option<String>,
+    severity: Option<SeverityLevel>,
+    timestamp: Option<DateTime<Utc>>,
+    properties: Option<Properties>,
+    tags: Option<ContextTags>,
+    measurements: Option<Measurements>,
+}
+
+impl TraceTelemetryBuilder {
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    pub fn with_severity(mut self, severity: SeverityLevel) -> Self {
+        self.severity = Some(severity);
+        self
+    }
+
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    pub fn with_properties(mut self, properties: Properties) -> Self {
+        self.properties = Some(properties);
+        self
+    }
+
+    pub fn with_tags(mut self, tags: ContextTags) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
+    pub fn with_measurements(mut self, measurements: Measurements) -> Self {
+        self.measurements = Some(measurements);
+        self
+    }
+
+    /// If no message is provided, an empty string is passed.
+    /// If no severity is provided, SeverityLevel::Verbose is used.
+    pub fn build(self) -> TraceTelemetry {
+        TraceTelemetry {
+            message: self.message.unwrap_or_else(String::new),
+            severity: self.severity.unwrap_or(SeverityLevel::Verbose),
+            timestamp: self.timestamp.unwrap_or_else(time::now),
+            properties: self.properties.unwrap_or_default(),
+            tags: self.tags.unwrap_or_default(),
+            measurements: self.measurements.unwrap_or_default(),
+        }
+    }
+}
+
 impl TraceTelemetry {
     /// Creates an event telemetry item with specified name.
     pub fn new(message: impl Into<String>, severity: SeverityLevel) -> Self {
@@ -59,6 +115,11 @@ impl TraceTelemetry {
             tags: ContextTags::default(),
             measurements: Measurements::default(),
         }
+    }
+
+    /// Create a new [TraceTelemetryBuilder], used to construct [TraceTelemetry].
+    pub fn builder() -> TraceTelemetryBuilder {
+        TraceTelemetryBuilder::default()
     }
 
     /// Returns custom measurements to submit with the telemetry item.

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -2,8 +2,8 @@ use chrono::{DateTime, SecondsFormat, Utc};
 
 use crate::{
     context::TelemetryContext,
-    contracts::{SeverityLevel as ContractsSeverityLevel, *},
-    telemetry::{ContextTags, Measurements, Properties, Telemetry},
+    contracts::*,
+    telemetry::{ContextTags, Measurements, Properties, SeverityLevel, Telemetry},
     time,
 };
 
@@ -185,37 +185,6 @@ impl From<(TelemetryContext, TraceTelemetry)> for Envelope {
                 ..MessageData::default()
             }))),
             ..Envelope::default()
-        }
-    }
-}
-
-/// Defines the level of severity for the event.
-#[derive(Debug)]
-pub enum SeverityLevel {
-    /// Verbose severity level.
-    Verbose,
-
-    /// Information severity level.
-    Information,
-
-    /// Warning severity level.
-    Warning,
-
-    /// Error severity level.
-    Error,
-
-    /// Critical severity level.
-    Critical,
-}
-
-impl From<SeverityLevel> for ContractsSeverityLevel {
-    fn from(severity: SeverityLevel) -> Self {
-        match severity {
-            SeverityLevel::Verbose => ContractsSeverityLevel::Verbose,
-            SeverityLevel::Information => ContractsSeverityLevel::Information,
-            SeverityLevel::Warning => ContractsSeverityLevel::Warning,
-            SeverityLevel::Error => ContractsSeverityLevel::Error,
-            SeverityLevel::Critical => ContractsSeverityLevel::Critical,
         }
     }
 }

--- a/appinsights/src/telemetry/trace.rs
+++ b/appinsights/src/telemetry/trace.rs
@@ -94,7 +94,7 @@ impl TraceTelemetryBuilder {
     /// If no severity is provided, SeverityLevel::Verbose is used.
     pub fn build(self) -> TraceTelemetry {
         TraceTelemetry {
-            message: self.message.unwrap_or_else(String::new),
+            message: self.message.unwrap_or_default(),
             severity: self.severity.unwrap_or(SeverityLevel::Verbose),
             timestamp: self.timestamp.unwrap_or_else(time::now),
             properties: self.properties.unwrap_or_default(),

--- a/appinsights/src/time.rs
+++ b/appinsights/src/time.rs
@@ -22,7 +22,7 @@ mod imp {
 
     use chrono::{DateTime, Utc};
 
-    thread_local!(static NOW: RefCell<Option<DateTime<Utc>>> = RefCell::new(None));
+    thread_local!(static NOW: RefCell<Option<DateTime<Utc>>> = const { RefCell::new(None) });
 
     /// Returns a DateTime which corresponds to a current date or the value user set in advance.
     pub fn now() -> DateTime<Utc> {
@@ -35,6 +35,7 @@ mod imp {
     }
 
     /// Resets pre-defined DateTime value to use Utc::now() instead.
+    #[expect(dead_code)]
     pub fn reset() {
         NOW.with(|ts| *ts.borrow_mut() = None)
     }

--- a/appinsights/src/transmitter.rs
+++ b/appinsights/src/transmitter.rs
@@ -25,7 +25,10 @@ pub struct Transmitter {
 impl Transmitter {
     /// Creates a new instance of telemetry items sender.
     pub fn new(url: &str) -> Self {
-        let client = Client::new();
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap();
         Self {
             url: url.into(),
             client,

--- a/appinsights/src/uuid.rs
+++ b/appinsights/src/uuid.rs
@@ -17,7 +17,7 @@ mod imp {
 
     use uuid::Uuid;
 
-    thread_local!(static ID: RefCell<Option<Uuid>> = RefCell::new(None));
+    thread_local!(static ID: RefCell<Option<Uuid>> = const { RefCell::new(None) });
 
     /// Generates a new instance of unique identifier or predefined value to test against it.
     pub fn new() -> Uuid {
@@ -36,6 +36,7 @@ mod imp {
     }
 
     /// Resets pre-defined Uuid value to use Uuid::new_v4() instead.
+    #[expect(dead_code)]
     pub fn reset() {
         ID.with(|is| *is.borrow_mut() = None)
     }

--- a/appinsights/tests/logger.rs
+++ b/appinsights/tests/logger.rs
@@ -6,14 +6,17 @@ use std::{
 use chrono::Utc;
 use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 
+#[allow(dead_code)]
 pub async fn wait_until(entries: &Arc<RwLock<Vec<String>>>, msg: &str, panic_after: Duration) {
     let panic_after = Utc::now() + chrono::Duration::from_std(panic_after).unwrap();
     loop {
-        let entries = entries.read().unwrap();
-        if entries.iter().any(|entry| entry.contains(msg)) {
-            break;
+        {
+            let entries = entries.read().unwrap();
+            if entries.iter().any(|entry| entry.contains(msg)) {
+                break;
+            }
+            drop(entries);
         }
-        drop(entries);
 
         if Utc::now() > panic_after {
             panic!("Test took too long to finish");
@@ -22,6 +25,7 @@ pub async fn wait_until(entries: &Arc<RwLock<Vec<String>>>, msg: &str, panic_aft
     }
 }
 
+#[allow(dead_code)]
 pub fn wait_until_blocking(entries: &Arc<RwLock<Vec<String>>>, msg: &str, panic_after: Duration) {
     let panic_after = Utc::now() + chrono::Duration::from_std(panic_after).unwrap();
     loop {
@@ -38,6 +42,7 @@ pub fn wait_until_blocking(entries: &Arc<RwLock<Vec<String>>>, msg: &str, panic_
     }
 }
 
+#[allow(dead_code)]
 pub fn init(entries: Arc<RwLock<Vec<String>>>) {
     builder(entries).init()
 }
@@ -61,6 +66,7 @@ impl Builder {
         }
     }
 
+    #[allow(dead_code)]
     pub fn level(&mut self, level: Level) -> &mut Self {
         self.level = level;
         self

--- a/appinsights/tests/telemetry.rs
+++ b/appinsights/tests/telemetry.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use appinsights::{telemetry::SeverityLevel, TelemetryClient};
-use hyper::{Method, Uri};
+use hyper::Uri;
 
 async fn panicking(message: &'static str) {
     panic!("{}", message);
@@ -27,7 +27,7 @@ async fn it_tracks_all_telemetry_items() {
         .track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
     ai.lock().unwrap().track_metric("gateway_latency_ms", 113.0);
     ai.lock().unwrap().track_request(
-        Method::GET,
+        "GET /dmolokanov/appinsights-rs".to_string(),
         "https://api.github.com/dmolokanov/appinsights-rs"
             .parse::<Uri>()
             .unwrap(),

--- a/appinsights/tests/telemetry.rs
+++ b/appinsights/tests/telemetry.rs
@@ -2,12 +2,16 @@ mod logger;
 
 use std::{
     env,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
 use appinsights::{telemetry::SeverityLevel, TelemetryClient};
 use hyper::{Method, Uri};
+
+async fn panicking(message: &'static str) {
+    panic!("{}", message);
+}
 
 #[tokio::test]
 async fn it_tracks_all_telemetry_items() {
@@ -15,12 +19,14 @@ async fn it_tracks_all_telemetry_items() {
     logger::builder(entries.clone()).output(true).init();
 
     let i_key = env::var("APPINSIGHTS_INSTRUMENTATIONKEY").expect("Set APPINSIGHTS_INSTRUMENTATIONKEY first");
-    let ai = TelemetryClient::new(i_key);
+    let ai = Arc::new(Mutex::new(TelemetryClient::new(i_key)));
 
-    ai.track_event("event happened");
-    ai.track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
-    ai.track_metric("gateway_latency_ms", 113.0);
-    ai.track_request(
+    ai.lock().unwrap().track_event("event happened");
+    ai.lock()
+        .unwrap()
+        .track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
+    ai.lock().unwrap().track_metric("gateway_latency_ms", 113.0);
+    ai.lock().unwrap().track_request(
         Method::GET,
         "https://api.github.com/dmolokanov/appinsights-rs"
             .parse::<Uri>()
@@ -28,19 +34,52 @@ async fn it_tracks_all_telemetry_items() {
         Duration::from_millis(100),
         "200".to_string(),
     );
-    ai.track_remote_dependency(
+    ai.lock().unwrap().track_remote_dependency(
         "GET https://api.github.com/dmolokanov/appinsights-rs",
         "HTTP",
         "api.github.com",
         true,
     );
-    ai.track_availability(
+    ai.lock().unwrap().track_availability(
         "GET https://api.github.com/dmolokanov/appinsights-rs",
         Duration::from_secs(2),
         true,
     );
 
-    ai.close_channel().await;
+    let weak = Arc::downgrade(&ai);
+    std::panic::set_hook(Box::new(move |info| {
+        let exception_type = "Panic";
+        let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+        let location = info.location().unwrap();
+        let problem_id = format!("{}:{}", exception_type, location);
+        let message = if let Some(str_message) = info.payload().downcast_ref::<&str>() {
+            str_message.to_string()
+        } else if let Some(string_message) = info.payload().downcast_ref::<String>() {
+            string_message.to_owned()
+        } else {
+            "couldn't parse panic message".to_string()
+        };
 
-    logger::wait_until(&entries, "Successfully sent 6 items", Duration::from_secs(10)).await;
+        if let Some(ai) = weak.upgrade() {
+            ai.lock().unwrap().track_exception(
+                format!("Panic occurred at {}: {}", location, message),
+                exception_type,
+                Some(backtrace),
+                Some(problem_id),
+            );
+        }
+    }));
+
+    let _ = tokio::spawn(async move { panicking("This task panicked!").await }).await;
+
+    match Arc::try_unwrap(ai) {
+        Ok(m) => {
+            m.into_inner().unwrap().close_channel().await;
+        }
+        _ => {
+            println!("Couldn't close channel");
+        }
+    }
+
+    logger::wait_until(&entries, "Successfully sent 7 items", Duration::from_secs(10)).await;
 }

--- a/appinsights/tests/telemetry_blocking.rs
+++ b/appinsights/tests/telemetry_blocking.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use appinsights::{blocking::TelemetryClient, telemetry::SeverityLevel};
-use hyper::{Method, Uri};
+use hyper::Uri;
 
 #[test]
 fn it_tracks_all_telemetry_items() {
@@ -21,7 +21,7 @@ fn it_tracks_all_telemetry_items() {
     ai.track_trace("Unable to connect to a gateway", SeverityLevel::Warning);
     ai.track_metric("gateway_latency_ms", 113.0);
     ai.track_request(
-        Method::GET,
+        "GET /dmolokanov/appinsights-rs".to_string(),
         "https://api.github.com/dmolokanov/appinsights-rs"
             .parse::<Uri>()
             .unwrap(),

--- a/patches/0001-build-add-macro-feature-to-tokio-dependency.patch
+++ b/patches/0001-build-add-macro-feature-to-tokio-dependency.patch
@@ -1,0 +1,31 @@
+From 46dd6cd7e6bf972e6cdadbbafb82c0a97a5e091a Mon Sep 17 00:00:00 2001
+From: Vegard Sandengen <vegardgs@ksat.no>
+Date: Tue, 14 Sep 2021 07:21:47 +0000
+Subject: [PATCH] build: add "macro" feature to tokio dependency
+
+In `src/channel/state`, we use the `tokio::select!` macro,
+which is only available with the "macro" feature. The build has passed
+fine in-repo because the Cargo.lock contains a reference to it, and it
+is pulled in. If one attempts to use appinsights-rs as a dependency to
+a crate without the tokio included, with the feature, it is not
+appropriately built, and building appinsights-rs fails.
+---
+ appinsights/Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/appinsights/Cargo.toml b/appinsights/Cargo.toml
+index cb456dc..d684bdc 100644
+--- a/appinsights/Cargo.toml
++++ b/appinsights/Cargo.toml
+@@ -35,7 +35,7 @@ uuid = { version = "0.8", features = ["v4"], default-features = false }
+ reqwest = { version = "0.11", features = ["json"], default-features = false }
+ log = "0.4"
+ sm = "0.9"
+-tokio = { version = "1", features = ["rt"], default-features = false }
++tokio = { version = "1", features = ["rt", "macros"], default-features = false }
+ paste = "1.0"
+ hostname = "0.3"
+ futures-util = { version = "0.3", default-features = false }
+-- 
+2.25.1
+

--- a/patches/0001-chore-updage-uuid-dependency-0.8-1.1.patch
+++ b/patches/0001-chore-updage-uuid-dependency-0.8-1.1.patch
@@ -1,0 +1,84 @@
+From 25768a955e0a42ebc8b76bf40be20e9ad684dfe8 Mon Sep 17 00:00:00 2001
+From: Vegard Sandengen <vegardgs@ksat.no>
+Date: Mon, 1 Aug 2022 08:00:38 +0000
+Subject: [PATCH] chore: updage uuid dependency 0.8 -> 1.1
+
+---
+ Cargo.lock                                | 4 ++--
+ appinsights/Cargo.toml                    | 2 +-
+ appinsights/src/telemetry/availability.rs | 2 +-
+ appinsights/src/telemetry/page_view.rs    | 2 +-
+ appinsights/src/telemetry/request.rs      | 2 +-
+ 5 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 675e2cf..44ab437 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1481,9 +1481,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "uuid"
+-version = "0.8.2"
++version = "1.1.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
++checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+ dependencies = [
+  "getrandom 0.2.1",
+ ]
+diff --git a/appinsights/Cargo.toml b/appinsights/Cargo.toml
+index d684bdc..eae8a9a 100644
+--- a/appinsights/Cargo.toml
++++ b/appinsights/Cargo.toml
+@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"], default-features = false }
+ serde_json = "1.0"
+ chrono = "0.4"
+ http = "0.2"
+-uuid = { version = "0.8", features = ["v4"], default-features = false }
++uuid = { version = "1.1", features = ["v4"], default-features = false }
+ reqwest = { version = "0.11", features = ["json"], default-features = false }
+ log = "0.4"
+ sm = "0.9"
+diff --git a/appinsights/src/telemetry/availability.rs b/appinsights/src/telemetry/availability.rs
+index d01e68a..cefc4da 100644
+--- a/appinsights/src/telemetry/availability.rs
++++ b/appinsights/src/telemetry/availability.rs
+@@ -133,7 +133,7 @@ impl From<(TelemetryContext, AvailabilityTelemetry)> for Envelope {
+             data: Some(Base::Data(Data::AvailabilityData(AvailabilityData {
+                 id: telemetry
+                     .id
+-                    .map(|id| id.to_hyphenated().to_string())
++                    .map(|id| id.as_hyphenated().to_string())
+                     .unwrap_or_default(),
+                 name: telemetry.name,
+                 duration: telemetry.duration.to_string(),
+diff --git a/appinsights/src/telemetry/page_view.rs b/appinsights/src/telemetry/page_view.rs
+index 81a86a1..d627a59 100644
+--- a/appinsights/src/telemetry/page_view.rs
++++ b/appinsights/src/telemetry/page_view.rs
+@@ -128,7 +128,7 @@ impl From<(TelemetryContext, PageViewTelemetry)> for Envelope {
+                 referrer_uri: None,
+                 id: telemetry
+                     .id
+-                    .map(|id| id.to_hyphenated().to_string())
++                    .map(|id| id.as_hyphenated().to_string())
+                     .unwrap_or_default(),
+                 properties: Some(Properties::combine(context.properties, telemetry.properties).into()),
+                 measurements: Some(telemetry.measurements.into()),
+diff --git a/appinsights/src/telemetry/request.rs b/appinsights/src/telemetry/request.rs
+index 7e671a1..10d2ca4 100644
+--- a/appinsights/src/telemetry/request.rs
++++ b/appinsights/src/telemetry/request.rs
+@@ -195,7 +195,7 @@ impl From<(TelemetryContext, RequestTelemetry)> for Envelope {
+             i_key: Some(context.i_key),
+             tags: Some(ContextTags::combine(context.tags, telemetry.tags).into()),
+             data: Some(Base::Data(Data::RequestData(RequestData {
+-                id: telemetry.id.unwrap_or_else(|| uuid::new().to_hyphenated().to_string()),
++                id: telemetry.id.unwrap_or_else(|| uuid::new().as_hyphenated().to_string()),
+                 name: Some(telemetry.name),
+                 duration: telemetry.duration.to_string(),
+                 response_code: telemetry.response_code,
+-- 
+2.25.1
+

--- a/patches/0001-feat-add-TraceTelemetryBuilder.patch
+++ b/patches/0001-feat-add-TraceTelemetryBuilder.patch
@@ -1,0 +1,91 @@
+From fbbf96563c5149a1752f00585a131c1cec6bcfbf Mon Sep 17 00:00:00 2001
+From: Vegard Sandengen <vegardgs@ksat.no>
+Date: Tue, 14 Sep 2021 07:24:23 +0000
+Subject: [PATCH] feat: add TraceTelemetryBuilder
+
+---
+ .../appinsights/src/telemetry/trace.rs        | 61 +++++++++++++++++++
+ 1 file changed, 61 insertions(+)
+
+diff --git a/appinsights/src/telemetry/trace.rs b/appinsights/src/telemetry/trace.rs
+index 03ec7e5..fa0dc53 100644
+--- a/appinsights/src/telemetry/trace.rs
++++ b/appinsights/src/telemetry/trace.rs
+@@ -48,6 +48,62 @@ pub struct TraceTelemetry {
+     measurements: Measurements,
+ }
+ 
++// This struct is a Option'fied version of TraceTelemetry
++#[derive(Debug, Default)]
++pub struct TraceTelemetryBuilder {
++    message: Option<String>,
++    severity: Option<SeverityLevel>,
++    timestamp: Option<DateTime<Utc>>,
++    properties: Option<Properties>,
++    tags: Option<ContextTags>,
++    measurements: Option<Measurements>,
++}
++
++impl TraceTelemetryBuilder {
++    pub fn with_message(mut self, message: impl Into<String>) -> Self {
++        self.message = Some(message.into());
++        self
++    }
++
++    pub fn with_severity(mut self, severity: SeverityLevel) -> Self {
++        self.severity = Some(severity);
++        self
++    }
++
++    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
++        self.timestamp = Some(timestamp);
++        self
++    }
++
++    pub fn with_properties(mut self, properties: Properties) -> Self {
++        self.properties = Some(properties);
++        self
++    }
++
++    pub fn with_tags(mut self, tags: ContextTags) -> Self {
++        self.tags = Some(tags);
++        self
++    }
++
++    pub fn with_measurements(mut self, measurements: Measurements) -> Self {
++        self.measurements = Some(measurements);
++        self
++    }
++
++    /// If no message is provided, an empty string is passed.
++    /// If no severity is provided, SeverityLevel::Verbose is used.
++    pub fn build(self) -> TraceTelemetry {
++        TraceTelemetry {
++            message: self.message.unwrap_or_else(String::new),
++            severity: self.severity.unwrap_or(SeverityLevel::Verbose),
++            timestamp: self.timestamp.unwrap_or_else(time::now),
++            properties: self.properties.unwrap_or_default(),
++            tags: self.tags.unwrap_or_default(),
++            measurements: self.measurements.unwrap_or_default(),
++        }
++    }
++}
++
+ impl TraceTelemetry {
+     /// Creates an event telemetry item with specified name.
+     pub fn new(message: impl Into<String>, severity: SeverityLevel) -> Self {
+@@ -61,6 +117,11 @@ impl TraceTelemetry {
+         }
+     }
+ 
++    /// Create a new [TraceTelemetryBuilder], used to construct [TraceTelemetry].
++    pub fn builder() -> TraceTelemetryBuilder {
++        TraceTelemetryBuilder::default()
++    }
++
+     /// Returns custom measurements to submit with the telemetry item.
+     pub fn measurements(&self) -> &Measurements {
+         &self.measurements
+-- 
+2.25.1
+

--- a/patches/0001-feat-add-set_-message-severity-to-TraceTelemetry.patch
+++ b/patches/0001-feat-add-set_-message-severity-to-TraceTelemetry.patch
@@ -1,0 +1,35 @@
+From e4c9ad3d205d597ed7815da154845ccfd6936682 Mon Sep 17 00:00:00 2001
+From: Vegard Sandengen <vegardgs@ksat.no>
+Date: Tue, 14 Sep 2021 06:54:13 +0000
+Subject: [PATCH] feat: add set_(message/severity) to TraceTelemetry
+
+In some cases, we are required to update the message/severity tag after
+the TraceTelemetry object has been constructed.
+---
+ appinsights/src/telemetry/trace.rs | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/appinsights/src/telemetry/trace.rs b/appinsights/src/telemetry/trace.rs
+index 3f5cef1..03ec7e5 100644
+--- a/appinsights/src/telemetry/trace.rs
++++ b/appinsights/src/telemetry/trace.rs
+@@ -70,6 +70,16 @@ impl TraceTelemetry {
+     pub fn measurements_mut(&mut self) -> &mut Measurements {
+         &mut self.measurements
+     }
++
++    /// Sets a new message of this trace telemetry.
++    pub fn set_message(&mut self, message: impl Into<String>) {
++        self.message = message.into();
++    }
++
++    /// Sets a new severity level of this trace telemetry.
++    pub fn set_severity(&mut self, severity: SeverityLevel) {
++        self.severity = severity;
++    }
+ }
+ 
+ impl Telemetry for TraceTelemetry {
+-- 
+2.25.1
+

--- a/patches/0001-feat-constrain-TelemetryChannel-with-Send-bound.patch
+++ b/patches/0001-feat-constrain-TelemetryChannel-with-Send-bound.patch
@@ -1,0 +1,30 @@
+From e553744065d685705618437838a1eee49e00d1b9 Mon Sep 17 00:00:00 2001
+From: Vegard Sandengen <vegardgs@ksat.no>
+Date: Tue, 14 Sep 2021 09:07:14 +0000
+Subject: [PATCH] feat: constrain TelemetryChannel with Send bound
+
+In order to appropriately wrap the TelementryClient in a Send + Sync
+environment, the trait object TelemetryChannel it holds, must constrain
+implementers of this trait to also be Send, in order to propagate the
+Send property to TelemetryClient. This allows it to be used in a
+threadpool environment.
+---
+ appinsights/src/channel/mod.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/appinsights/src/channel/mod.rs b/appinsights/src/channel/mod.rs
+index 40effc3..601d4e2 100644
+--- a/appinsights/src/channel/mod.rs
++++ b/appinsights/src/channel/mod.rs
+@@ -14,7 +14,7 @@ use crate::contracts::Envelope;
+ /// An implementation of [TelemetryChannel](trait.TelemetryChannel.html) is responsible for queueing
+ /// and periodically submitting telemetry events.
+ #[async_trait]
+-pub trait TelemetryChannel {
++pub trait TelemetryChannel: Send {
+     /// Queues a single telemetry item.
+     fn send(&self, envelop: Envelope);
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
We are observing stalled telemetry submissions, and have weeded it down to the telemetry client unable to continue after issuing a send operation.

We can observe from console logs the following:
```
Timeout expired
Sending 42 telemetry items triggered by TimeoutExpired 
```

Expecting an line with the following on success: `Successfully sent 42 items`. This line never arrives.
